### PR TITLE
Bump SDK to 1.0.33 as well as tour and Lambda greeter versions

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -58,9 +58,9 @@ const config = {
               {
                 replacements: {
                   RESTATE_DIST_VERSION: '0.1.7',
-                  TYPESCRIPT_SDK_VERSION: '1.0.32',
-                  TOUR_VERSION: 'v0.0.3',
-                  LAMBDA_GREETER_VERSION: 'v0.0.3'
+                  TYPESCRIPT_SDK_VERSION: '1.0.33',
+                  TOUR_VERSION: 'v0.0.4',
+                  LAMBDA_GREETER_VERSION: 'v0.0.4'
                 },
               }
             ]


### PR DESCRIPTION
This commit bumps the SDK version to 1.0.33 and the tour as well as the Lambda greeter version to 0.0.4.