### PR TITLE
Remove instructions for how get access to restate-dist

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ docker run --rm -p 3000:80 ghcr.io/restatedev/documentation:latest
 
 This will serve the documentation under `localhost:3000`.
 
-> **Note**
-> Make sure that you have access to Github's container registry by [following these instructions](https://github.com/restatedev/restate-dist#container-registry).
-
 You can also check this repository out and build the documentation yourself by following the instructions below.
 
 ## Developing the documentation
@@ -51,7 +48,7 @@ The `main` branch of the documentation is continuously deployed at `https://main
 
 Before releasing the documentation, update schemas and version of Restate artifacts, either:
 
-* Automatically by executing the _Pre-release updates_ workflow. 
+* Automatically by executing the _Pre-release updates_ workflow.
 * Manually, as described below.
 
 Once the branch `main` is ready to be released, merge `main` in `production` and push it, together with the release tag. E.g:

--- a/docs/services/deployment/lambda.md
+++ b/docs/services/deployment/lambda.md
@@ -46,7 +46,6 @@ This tutorial shows how to deploy a greeter service written with the Restate Typ
 [Go to the GitHub repository of this tutorial](https://github.com/restatedev/examples/tree/main/typescript/lambda-greeter)
 
 ### Prerequisites
-> &#x1F4DD; As long as Restate hasn't been launched publicly, you need to have access to the private Restate npm packages and Docker container. Please follow the instructions in the [restate-dist](https://github.com/restatedev/restate-dist) Readme to set up access:
 
 - Latest stable version of [NodeJS](https://nodejs.org/en/) >= v18.17.1 and [npm CLI](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= 9.6.7
 - [Docker Engine](https://docs.docker.com/engine/install/) or [Podman](https://podman.io/docs/installation) to launch the Restate runtime (not needed for the app implementation itself).

--- a/docs/tour.mdx
+++ b/docs/tour.mdx
@@ -30,7 +30,6 @@ The ticket example has three services, with the following functions:
 As we go, you will discover how Restate can help you with some intricacies in this application.
 
 ## Prerequisites
-> &#x1F4DD; As long as Restate hasn't been launched publicly, you need to have access to the private Restate npm packages and Docker container. Please follow the instructions in the [restate-dist/README](https://github.com/restatedev/restate-dist) to set up access:
 
 - Latest stable version of [NodeJS](https://nodejs.org/en/) >= v18.17.1 and [npm CLI](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= 9.6.7 installed.
 - [Docker Engine](https://docs.docker.com/engine/install/) or [Podman](https://podman.io/docs/installation) to launch the Restate runtime (not needed for the app implementation itself).


### PR DESCRIPTION
restatedev/restate-dist is now public. Therefore, we can remove the instructions for how to set up access to it.