### PR TITLE
Link restate-holiday from docs Examples pages

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,13 +12,14 @@ Pick an example from the list below and follow the instructions in the README to
 
 ## Starter examples
 
-- [AWS Lambda greeter](https://github.com/restatedev/examples/tree/main/typescript/lambda-greeter): A simple example of how you can run a Restate service on AWS Lambda.
+- [AWS Lambda Hello World](https://github.com/restatedev/examples/tree/main/typescript/hello-world-lambda): A simple example of how you can run a Restate service on AWS Lambda.
 - [Stripe payment API](https://github.com/restatedev/examples/tree/main/typescript/payment-api): This example shows how to build a reliable and consistent Stripe-style payment API with Restate.
 
 ## Intermediate examples
 
-- [Ticket reservation system](https://github.com/restatedev/examples/tree/main/typescript/ticket-reservation):  a subset of a ticket booking system to illustrate how Restate's keyed-sharding and concurrency guarantees simplify microservice architectures.
+- [Ticket reservation system](https://github.com/restatedev/examples/tree/main/typescript/ticket-reservation): A subset of a ticket booking system to illustrate how Restate's keyed-sharding and concurrency guarantees simplify microservice architectures.
 - [Food ordering](https://github.com/restatedev/examples/tree/main/typescript/food-ordering): The (serverless) order processing app of a fast food chain implemented with awakeables.
+- [Service orchestration](https://github.com/restatedev/restate-holiday.git): The holiday trip booking flow from our [Restate with Lambda blog post](https://restate.dev/blog/suspendable-functions-make-lambda-the-perfect-application-platform/) demonstrates complex business process modeling and failure compensation. It also showcases the [Restate CDK constructs](https://github.com/restatedev/cdk) and includes an optional self-hosted single-node Restate deployment on AWS.
 
 ## Advanced examples
 


### PR DESCRIPTION
- Add a link to restate-holiday in the Intermediate examples section
- Fix a broken link to Lambda hello-world