### PR TITLE
Add shortcuts to SDKs and allow query parameters 

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -20,7 +20,7 @@ This guide takes you through your first steps with Restate.
 
 Scaffold the project to create your first service:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="typescript" label="Typescript" default>
 
 Use the [Node template](https://github.com/restatedev/node-template-generator) to get started.
@@ -50,7 +50,7 @@ wget https://github.com/restatedev/examples/releases/latest/download/java-hello-
 
 ## Step 2: Build and run the service
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="typescript" label="Typescript" default>
 
 Now, you are all set to start developing your service in `src/app.ts`.
@@ -145,7 +145,7 @@ After executing this curl request, you should see the discovered services and me
 
 Invoke the function via:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="typescript" label="Typescript" default>
 
 ```shell

--- a/docs/services/sdk/awakeables.mdx
+++ b/docs/services/sdk/awakeables.mdx
@@ -30,7 +30,7 @@ They block until the invocation is finished, so until the awakeable ID is return
 
 You can use awakeables in the SDK by doing the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript
@@ -78,7 +78,7 @@ The external process that received the ID, needs to deliver it back to Restate w
 If the external process is another Restate service, then you can use the SDK to resolve the awakeable (= to send the ID back).
 Use the awakeable ID that you received from the other service, and do the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript
@@ -104,7 +104,7 @@ For other types, have a look at the [serialization documentation](/services/sdk/
 
 You can also reject an awakeable, that is completing it with a failure. This will cause the waiting service to throw [a terminal error](/services/sdk/error-handling):
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript

--- a/docs/services/sdk/durable-timers.mdx
+++ b/docs/services/sdk/durable-timers.mdx
@@ -18,7 +18,7 @@ When the service sleeps, costs are reduced to zero.
 
 To sleep in a Restate application for ten seconds, do the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript

--- a/docs/services/sdk/error-handling.mdx
+++ b/docs/services/sdk/error-handling.mdx
@@ -15,7 +15,7 @@ By default, Restate does infinite retries with an exponential backoff strategy.
 For situations where you do not want the invocation to be retried, but instead you want the error message
 to be propagated back to the caller, you can use a terminal error.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript

--- a/docs/services/sdk/kafka.mdx
+++ b/docs/services/sdk/kafka.mdx
@@ -27,7 +27,7 @@ Depending on your use case you can build different types of event handlers. We d
 
 An event handlers can profit from the same features as other Restate handlers, including durable execution, [service communication](/services/sdk/service-communication) and [side effects](/services/sdk/side-effects).
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 ** Handling events with string key **
@@ -301,7 +301,7 @@ $ curl <RESTATE_META_ENDPOINT>/subscriptions --json '{"source": "kafka://<CLUSTE
 
 For example:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 ```bash

--- a/docs/services/sdk/logging.mdx
+++ b/docs/services/sdk/logging.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 # Logging
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 The Restate SDK allows different log levels by setting the environment variable `RESTATE_DEBUG_LOGGING`.

--- a/docs/services/sdk/overview.mdx
+++ b/docs/services/sdk/overview.mdx
@@ -12,7 +12,7 @@ Restate offers a Java SDK ([sdk-java repo](https://github.com/restatedev/sdk-jav
 
 ## Installation
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 :::tip
@@ -101,7 +101,7 @@ For Maven you can use the [xolstice Protobuf plugin](https://www.xolstice.org/pr
 
 ## API Examples
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 Below is an example of a Typescript service with the Handler API.

--- a/docs/services/sdk/restate-context.mdx
+++ b/docs/services/sdk/restate-context.mdx
@@ -14,7 +14,7 @@ calling other services.
 
 You can retrieve the context object as follows:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 ```typescript

--- a/docs/services/sdk/serialization.mdx
+++ b/docs/services/sdk/serialization.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 For some SDK operations, Restate needs to send data over the network, for example for storing state, doing side effects and awakeables.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 The SDK serializes values with `Buffer.from(JSON.stringify(payload))` and deserializes them with `JSON.parse(result.toString()) as T`.

--- a/docs/services/sdk/service-communication.mdx
+++ b/docs/services/sdk/service-communication.mdx
@@ -16,7 +16,7 @@ Let's assume we have a `Greeter` service running next to the service we are curr
 This `Greeter` service has a method called `Greet` that takes an input request containing a `name` as a `string`.
 To make request-response calls to the `Greeter` service, do the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 On the side of the service that you are going to call, you export the API definition, as follows (for more details look at the [serving docs](/services/sdk/serving)): 
@@ -100,7 +100,7 @@ A one-way call is a call from one service to another service where the client do
 Without Restate, this is usually implemented by adding a message queue in between the two services. 
 Restate eliminates the need for a message queue because Restate durably logs the request and makes sure it gets executed.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 On the side of the service that you are going to call, you export the API definition as shown in the [request-response calls section](/services/sdk/service-communication#request-response-calls).
@@ -173,7 +173,7 @@ ctx.oneWayCall(
 A delayed call is a one-way call that gets executed after a specified delay.
 
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 On the side of the service that you are going to call, you export the API definition as shown in the [request-response calls section](/services/sdk/service-communication#request-response-calls).

--- a/docs/services/sdk/serving.mdx
+++ b/docs/services/sdk/serving.mdx
@@ -14,7 +14,7 @@ Restate services can run in two ways: as long-running services or as AWS Lambda 
 
 To register your service as a long-running service, do the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 **1. Define a router for your keyed or unkeyed service**
@@ -145,7 +145,7 @@ Finally, call `buildAndListen(port)` to have the RestateServer listen on the spe
 To register your service as a Lambda function,
 only minimal changes are required, as compared to the long-running service:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript" default>
 
 ```typescript

--- a/docs/services/sdk/side-effects.mdx
+++ b/docs/services/sdk/side-effects.mdx
@@ -20,7 +20,7 @@ and that the value is retained during replays.
 
 Here is an example in which a unique ID is generated and stored in Restate:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript
@@ -56,7 +56,7 @@ This includes actions such as getting state, calling another service, and nestin
 
 If the side effect closure throws an error, then it is retried infinitely using an exponential backoff strategy until it succeeds.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript
@@ -146,7 +146,7 @@ If you want to let the side effect fail terminally, then you have to throw a ter
 A terminal error will stop the infinite retry strategy and lets the SDK propagate the error to the user code where it can be handled.
 The terminal error will also be recorded in the journal so that it will be deterministically thrown on replay.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 You can throw a terminal error by using `restate.TerminalError`:

--- a/docs/services/sdk/state.mdx
+++ b/docs/services/sdk/state.mdx
@@ -13,7 +13,7 @@ Using this feature requires no additional setup.
 ## Retrieving state
 To retrieve state in Restate, you can do the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript
@@ -72,7 +72,7 @@ This will return either the value that was stored or `null` if no value was stor
 ## Setting state
 To set a key-value pair in Restate, do:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript
@@ -106,7 +106,7 @@ Replace `my-new-value` with the value that you want to set.
 ## Clearing state
 To delete the value of a key in Restate, do:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript

--- a/docs/services/service_type.mdx
+++ b/docs/services/service_type.mdx
@@ -30,7 +30,7 @@ A common use case for keyed services is to model an entity of your application. 
 
 Because keyed services are executed serially on a per-key basis, it means that invocations will execute in the same order in which they are enqueued. For example, assume the following code in `ServiceA`:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="Typescript">
 
 ```typescript

--- a/docs/tour.mdx
+++ b/docs/tour.mdx
@@ -30,7 +30,7 @@ As we go, you will discover how Restate can help you with some intricacies in th
 
 ## Prerequisites
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 - Latest stable version of [NodeJS](https://nodejs.org/en/) >= v18.17.1 and [npm CLI](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= 9.6.7 installed.
@@ -64,7 +64,7 @@ This guide is written for:
 
 ### Setting up the tutorial
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 Clone the GitHub repository of the [tutorial](https://github.com/restatedev/tour-of-restate):
@@ -97,7 +97,7 @@ This GitHub repository contains the basic skeleton of the Java services that you
 
 Let's start a basic version of the Restate services that we will be using for this tour. This is where our application logic will reside.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```shell
@@ -179,7 +179,7 @@ You can pipe the output of `curl` into the `jq` utility to reformat the JSON out
 
 You should now see the registered services printed out to your terminal:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```json
@@ -237,7 +237,7 @@ You should now see the registered services printed out to your terminal:
 
 The Restate logs will show the new service registrations taking place.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 <details>
 <summary>Show the runtime logs</summary>
@@ -299,7 +299,7 @@ For MacOS users, the address will be `http://host.docker.internal:9080/`.
 
 Add a ticket to a cart by calling `UserSession/addTicket`.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```shell
@@ -324,7 +324,7 @@ If this prints out `true`, then you have a working setup.
 
 You can call the `UserSession/checkout` function to proceed with the purchase, as follows:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```shell
@@ -376,7 +376,7 @@ So at most one invocation can run at a time for the same ticket ID or user ID re
 
 ### Specifying the service type
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 **Specifying unkeyed services**
@@ -534,7 +534,7 @@ When the `UserSession/addTicket` function is called, it first needs to reserve t
 It does that by calling the `TicketService/reserve` function.
 Add the highlighted code snippet to the `addTicket` function in the `UserSession` service.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -647,7 +647,7 @@ To see this work in practice, let's pretend that ticket reservations take a whil
 This is not the best way to sleep in a Restate service! The Restate SDK offers a native way to suspend execution for a period of time. We will cover [suspendable sleep a bit later on](#suspendable-sleep) in the tour.
 :::
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -767,7 +767,7 @@ You will fix this later on.
 
 Add the following code to the `UserSession/checkout` function:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -843,7 +843,7 @@ Restart the service and call the `UserSession/checkout` function as you did earl
 
 Up to now, all our service calls waited for a response. This is referred to as request-response or synchronous RPC. With Restate, you can also make one-way calls where you don't wait for the response.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 Update `expireTicket` to use `RpcContext.send` to send a one-way message to release the reservation:
@@ -943,7 +943,7 @@ Let the `expireTicket` function call the `TicketService/unreserve` function.
 
 When you are done with the implementation, send a request to `UserSession/expireTicket` to check if it works.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 <details>
@@ -1054,7 +1054,7 @@ Restate offers the same mechanism for timers.
 
 [Earlier in this tutorial](#waiting-for-slow-services), you saw how Restate caller suspension works when you make an RPC request to another service. We artificially slowed down the target service by using platform-native sleep. Sometimes you intentionally want to suspend execution for a period of time, for example to back off from overloading a dependency or simply you are implementing a long-running business workflow. In those situations you can explicitly suspend execution for arbitrarily long periods of time using the Restate context's `sleep` function. Adapt the `TicketService/reserve` function to use `ctx.sleep`:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -1089,7 +1089,7 @@ The `addTicket` function did a one-way call to the `reserve` function so didn't 
 
 <details>
 <summary>Show the logs</summary>
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```log
@@ -1145,7 +1145,7 @@ You see the invocation suspending after 60 seconds. And being re-invoked 5 secon
 
 In `UserSession/addTicket`, revert the call to `reserve` to a request-response call, to see how the suspensions work across different services.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 Replace the `RpcContext.send()` with `RpcContext.rpc()`, to end up with:
@@ -1271,7 +1271,7 @@ To do this, you can use a delayed call.
 This is a one-way call that gets delayed by a specified duration.
 This would make the `UserSession/addTicket` function look as follows:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -1327,7 +1327,7 @@ To test it out, put the delay to a lower value, for example 5 seconds, call the 
 
 <details>
 <summary>Show the logs</summary>
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```log
@@ -1383,7 +1383,7 @@ Don't forget to set the delay back to 15 minutes.
 You can implement this pattern in different ways.
 You could also sleep for 15 minutes at the end of the `addTicket` function and then call the `TicketService/unreserve` function:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -1439,7 +1439,7 @@ Adapt the `UserSession/addTicket` function to keep track of the cart items.
 After reserving the product, you add the ticket to the shopping cart.
 Have a look at the highlighted code:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -1519,7 +1519,7 @@ After you added the ticket to the cart array, you set the state to the new value
 
 Run the services and call the `addTicket` function, to see the interaction with state.
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 <details>
@@ -1581,7 +1581,7 @@ You can also stop and relaunch the service or restart the runtime (`docker resta
 
 Also adapt the `UserSession/checkout` function, to use the tickets:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -1668,7 +1668,7 @@ Have a look at the documentation on [introspection](/services/introspection/) to
 
 You have almost fully implemented the user session service. After checkout, let's finish `UserSession/expireTicket`. At the moment you have the following code:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -1702,7 +1702,7 @@ If this is the case, then you call `TicketService/unreserve` and remove it from 
 <details>
 <summary>Solution</summary>
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -1791,7 +1791,7 @@ Remove the sleep that you added before.
 <details>
 <summary>Solution</summary>
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -1842,7 +1842,7 @@ The function should clear the value of the `"status"` key if it's not on status 
 <details>
 <summary>Solution</summary>
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -1886,7 +1886,7 @@ The function should set the value of the `"status"` key to `TicketStatus.Sold` i
 <details>
 <summary>Solution</summary>
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -1925,7 +1925,7 @@ This ties the final parts together.
 :::info
 🚩 Explore the intermediate solution in `part2`, and run it with:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```shell
@@ -1961,7 +1961,7 @@ This includes pieces of time-consuming, deterministic user code.
 
 Use a side effect in `Checkout/checkout` to create and store a UUID (with the [uuid library](https://www.npmjs.com/package/uuid)) or idempotency key:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -1999,7 +1999,7 @@ When the `checkout()` function gets re-executed upon replay, Restate injects the
 
 To experiment, you can print the idempotency key to the console and add a sleep to see how the UUID gets replayed after the suspension:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -2022,7 +2022,7 @@ Call `UserSession/checkout` and have a look at the logs to see what happens.
 <details>
 <summary>Show the logs</summary>
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```log
@@ -2105,7 +2105,7 @@ Also return the boolean result at the end of the `checkout` function.
 <details>
 <summary>Solution</summary>
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -2212,7 +2212,7 @@ Once this works, you implement the rest of the checkout workflow:
 
 The `Checkout/checkout` function now looks like the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -2275,7 +2275,7 @@ public BoolValue checkout(RestateContext ctx, CheckoutFlowRequest request) throw
 
 The `UserSession/checkout` function now looks like the following:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```ts
@@ -2346,7 +2346,7 @@ Try it out by reserving some new tickets and buying them by checking out the car
 :::info
 🚩 Explore the intermediate solution in `part3`, and run it with:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```shell
@@ -2390,7 +2390,7 @@ These features are switched on by default. No need to do anything.
 Also side effects are retried until they succeed.
 You can observe this behavior by using the `paymentClient.failingCall` in `Checkout/checkout`:
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
@@ -2419,7 +2419,7 @@ Have a look at the logs to see the retries.
 <details>
 <summary>Show the logs</summary>
 
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```log
@@ -2675,7 +2675,7 @@ For more information, have a look at the [tracing docs](/restate/tracing).
 You reached the end of this tutorial!
 
 :::info 🚩 Have a look at the fully implemented app in `part4`, and run it with:
-<Tabs groupId="sdk">
+<Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
 ```shell

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -200,6 +200,9 @@ const config = {
       },
     },
   themes: ["docusaurus-json-schema-plugin"],
+  scripts: [
+      '/js/store-query-parameter.js',
+  ]
 };
 
 module.exports = config;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,6 +89,16 @@ const config = {
         },
         items: [
           {
+            href: "/services/sdk/overview?sdk=ts",
+            label: "Typescript SDK",
+            position: "right",
+          },
+          {
+            to: "/services/sdk/overview?sdk=java",
+            label: "Java SDK",
+            position: "right",
+          },
+          {
             href: "https://discord.gg/skW3AZ6uGd",
             html: '<svg xmlns="http://www.w3.org/2000/svg" width="25" height="20" fill="none" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"  viewBox="0 0 127.14 96.36"><g id="图层_2" data-name="图层 2"><g id="Discord_Logos" data-name="Discord Logos"><g id="Discord_Logo_-_Large_-_White" data-name="Discord Logo - Large - White"><path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/></g></g></g></svg>',
             position: "right",

--- a/static/js/store-query-parameter.js
+++ b/static/js/store-query-parameter.js
@@ -1,0 +1,21 @@
+// This script stores the 'sdk' parameter value in the local storage
+// so that the preferred SDK tab stays selected, as the user clicks through the UI.
+// The default docusaurus behavior only stores the sdk preference in local storage if the user clicked on a specific tab,
+// it didn't store the query parameters in local storage. So the query parameters would get lost on subsequent clicks.
+const storeSelectedSDK = function () {
+    console.info("Running sdk language parameter recognition script: " + window.location.search);
+    const urlParams = new URLSearchParams(window.location.search);
+    const sdkParam = urlParams.get('sdk');
+
+    // Check if the 'sdk' parameter is present in the URL
+    if (sdkParam !== null) {
+        // Store the 'sdk' parameter value in the local storage
+        console.info("Setting sdk local storage parameter to: " + sdkParam);
+        localStorage.setItem('docusaurus.tab.sdk', sdkParam);
+    }
+}
+
+// On window load
+window.onload = storeSelectedSDK;
+// On any subsequent click which doesn't reload the page
+document.addEventListener('click', storeSelectedSDK);

--- a/static/js/store-query-parameter.js
+++ b/static/js/store-query-parameter.js
@@ -3,14 +3,11 @@
 // The default docusaurus behavior only stores the sdk preference in local storage if the user clicked on a specific tab,
 // it didn't store the query parameters in local storage. So the query parameters would get lost on subsequent clicks.
 const storeSelectedSDK = function () {
-    console.info("Running sdk language parameter recognition script: " + window.location.search);
     const urlParams = new URLSearchParams(window.location.search);
     const sdkParam = urlParams.get('sdk');
 
-    // Check if the 'sdk' parameter is present in the URL
     if (sdkParam !== null) {
         // Store the 'sdk' parameter value in the local storage
-        console.info("Setting sdk local storage parameter to: " + sdkParam);
         localStorage.setItem('docusaurus.tab.sdk', sdkParam);
     }
 }


### PR DESCRIPTION
Fixes #226 
- Adds shortcuts to Java and TS SDK in header
- Allows query parameters to open docs for specific languague without having to select the tab anymore