### PR TITLE
Update the CDK library documentation with the 0.7.0 API changes

### DIFF
--- a/docs/restate/deployment.md
+++ b/docs/restate/deployment.md
@@ -4,9 +4,11 @@ description: "Deploy Restate on Kubernetes with this guide."
 ---
 
 # Deployment
+
 Restate is currently a single binary that contains everything you need. You can obtain the binary from the
 [releases page](https://github.com/restatedev/restate/releases), as part of a
-[Docker image](https://hub.docker.com/r/restatedev/restate), from our [Homebrew tap](https://github.com/restatedev/homebrew-tap)
+[Docker image](https://hub.docker.com/r/restatedev/restate), from
+our [Homebrew tap](https://github.com/restatedev/homebrew-tap)
 with `brew install restatedev/tap/restate`, or from [npm](https://www.npmjs.com/package/@restatedev/restate)
 with `npm install @restatedev/restate-server`.
 
@@ -19,13 +21,15 @@ The binary exposes four services by default, each on different ports:
 | Admin     | 9070 | Allows for CRUD operations on service/service deployment metadata, eg for service registration                                 | REST                                              |
 | Postgres  | 9071 | Exposes Restate RocksDB read-only storage operations using the Postgres protocol. See [Introspection](/services/introspection) | Postgres                                          |
 
-It will store metadata and RocksDB data in the relative directory of /target under the current working directory of the process.
+It will store metadata and RocksDB data in the relative directory of /target under the current working directory of the
+process.
 
 It requires outbound connectivity to services in order to discover them and to send requests.
 
 ## Kubernetes
 
-The recommended Kubernetes deployment strategy is a one-replica StatefulSet. We recommend installing Restate in its own namespace.
+The recommended Kubernetes deployment strategy is a one-replica StatefulSet. We recommend installing Restate in its own
+namespace.
 
 ```yaml
 apiVersion: v1
@@ -110,8 +114,8 @@ The [Restate CDK support library](https://www.npmjs.com/package/@restatedev/rest
 for managing Restate server deployments on AWS. We currently offer support for a simple single-node deployment to Amazon
 EC2.
 
-If you don't have an existing CDK project, follow the CDK [Getting started](https://docs.aws.amazon.com/cdk/v2/guide/hello_world.html)
-page to set one up.
+If you don't have an existing CDK project, follow the
+CDK [Getting started](https://docs.aws.amazon.com/cdk/v2/guide/hello_world.html) page to set one up.
 
 ### Adding the Restate CDK support library
 
@@ -123,14 +127,15 @@ npm install @restatedev/restate-cdk
 
 ### Deploying a single-node Restate server
 
-The `SingleNodeRestateInstance` construct deploys a single-node server on Amazon EC2, suitable for development purposes.
-A single EC2 instance will be deployed in a new internet-connected VPC – or you can provide one explicitly. You can
-optionally enable tracing integration, which will grant the instance role permission to send traces to AWS X-Ray.
+The `SingleNodeRestateDeployment` construct deploys a single-node server on Amazon EC2, suitable for development
+purposes. An EC2 instance will be created in a new internet-connected VPC – alternatively, you can provide one
+explicitly. You can optionally enable tracing integration, which will grant the instance role permission to send traces
+to AWS X-Ray.
 
 ```typescript
 import * as restate from "@restatedev/restate-cdk";
 
-const restateService = new restate.SingleNodeRestateInstance(scope, "RestateServer", {
+const environment = new restate.SingleNodeRestateDeployment(this, "Restate", {
   restateTag: "latest",
   tracing: restate.TracingMode.AWS_XRAY,
   logGroup: new logs.LogGroup(scope, "RestateLogs", {

--- a/docs/restate/deployment.md
+++ b/docs/restate/deployment.md
@@ -1,18 +1,13 @@
 ---
 sidebar_position: 3
-description: "Deploy Restate on Kubernetes with this guide."
+description: "Deploy Restate on Kubernetes or to AWS with this guide."
 ---
 
 # Deployment
 
-Restate is currently a single binary that contains everything you need. You can obtain the binary from the
-[releases page](https://github.com/restatedev/restate/releases), as part of a
-[Docker image](https://hub.docker.com/r/restatedev/restate), from
-our [Homebrew tap](https://github.com/restatedev/homebrew-tap)
-with `brew install restatedev/tap/restate`, or from [npm](https://www.npmjs.com/package/@restatedev/restate)
-with `npm install @restatedev/restate-server`.
+Restate is a single binary that contains everything you need to host an environment. See the [Get Restate](https://restate.dev/get-restate/) page for various ways of obtaining it.
 
-The binary exposes four services by default, each on different ports:
+The server process exposes four services by default, available on different ports:
 
 | Name      | Port | Description                                                                                                                    | Protocol                                          |
 |-----------|------|--------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
@@ -24,7 +19,9 @@ The binary exposes four services by default, each on different ports:
 It will store metadata and RocksDB data in the relative directory of /target under the current working directory of the
 process.
 
-It requires outbound connectivity to services in order to discover them and to send requests.
+The Restate server requires outbound connectivity to the services you deploy in order to discover and send requests to them.
+
+In the next sections we will show you two different ways to deploy Restate on your own infrastructure.
 
 ## Kubernetes
 

--- a/docs/services/deployment/cdk.mdx
+++ b/docs/services/deployment/cdk.mdx
@@ -32,7 +32,7 @@ Add the Restate CDK support library to your project:
 npm install @restatedev/restate-cdk
 ```
 
-### Deploy your handler code to AWS Lambda
+### Deploy your handlers to AWS Lambda
 
 Define one or more Lambda functions in your CDK stack to model the service handlers in your chosen language. Depending
 on the SDK and programming language, you may need an additional build process such as Gradle, to bundle your business
@@ -83,47 +83,44 @@ const service: lambda.Function = new lambda.Function(scope, "RestateService", {
 Restate is [very easy to deploy](/restate/deployment), and we provide a CDK construct to make it super simple to deploy
 a self-hosted development server on Amazon EC2. Once you have a Restate service, you can optionally deploy your own
 Restate server in the same or separate CDK stack.
-See [Deploying Restate on Amazon EC2 with CDK](/restate/deployment#amazon-ec2-with-cdk) for more information on using
-the `SingleNodeRestateInstance` construct.
+See [Deploying Restate on Amazon EC2 with CDK](/restate/deployment#amazon-ec2-with-cdk) for more information on how to
+deploy Restate itself in your own CDK stack.
 
-### Register Lambda-based services with Restate
+### Register Lambda-deployed services with a Restate environment
 
 To enable our Lambda handlers to receive Restate requests, we need to create a deployment with Restate.
 The `LambdaServiceRegistry` construct represents a collection of Lambda-backed Restate services and takes
 care of creating/updating Restate Deployments backed by the specified Lambda functions any time you deploy a change
 to your stack. Restate uses Lambda versioning to consistently target the same function configuration from a given
-deployment revision.
+deployment revision. Note that this is a quiescent component: it deploys a custom CloudFormation resource provider which
+is only activated during changes to the referenced Lambda functions, typically while you deploy your CDK stack. 
 
 <Tabs>
 <TabItem value="cloud" label="Restate Cloud" default>
 
-When using Restate Cloud managed service, you model it with the `RestateCloudEndpoint` construct. As well as holding
+When using Restate Cloud managed service, you model it with the `RestateCloudEnvironment` construct. As well as holding
 the specific configuration properties, this construct creates an IAM role that can be assumed by the Restate Managed
 Service AWS account, with permission to invoke any version of all the listed service handlers Lambda functions.
 
 :::caution
-The `RestateCloudEndpoint` construct creates an IAM role that can be assumed by the Restate Managed Service AWS account!
+The `RestateCloudEnvironment` construct creates an IAM role that can be assumed by the Restate Cloud AWS service account
+in order to be able to invoke your services.
 :::
 
 ```typescript
 import * as restate from "@restatedev/restate-cdk";
 
-const restateService = new restate.RestateCloudEndpoint(scope, "RestateCloud", {
+const environment = new restate.RestateCloudEnvironment(scope, "RestateCloud", {
   clusterId: "restate-cluster-id",
   authTokenSecretArn: restateAuthToken.secretFullArn,
 });
 
-const handlers = new restate.LambdaServiceRegistry(scope, "RestateServiceRegistry", {
-  serviceHandlers: {
+const handlers = new restate.LambdaServiceRegistry(scope, "ServiceRegistry", {
+  environment,
+  handlers: {
     "namespace.Service": service,
-    // additional handlers as needed
+    // ...additional handlers as needed
   },
-  restate: restateService,
-});
-handlers.register({
-  metaEndpoint: restateService.metaEndpoint,
-  invokerRoleArn: restateService.invokerRole.roleArn,
-  authTokenSecretArn: restateService.authToken.secretArn,
 });
 ```
 </TabItem>
@@ -132,19 +129,19 @@ handlers.register({
 ```typescript
 import * as restate from "@restatedev/restate-cdk";
 
-// const restateService: restate.SingleNodeRestateInstance = ...;
-
-const handlers = new restate.LambdaServiceRegistry(scope, "RestateServiceRegistry", {
-  serviceHandlers: {
-    "namespace.Service": service,
-    // additional handlers as needed
-  },
-  restate: restateService,
+new restate.SingleNodeRestateDeployment(scope, "Restate", {
+  logGroup: new logs.LogGroup(scope, "RestateLogs", {
+    retention: logs.RetentionDays.THREE_MONTHS,
+    removalPolicy: cdk.RemovalPolicy.DESTROY,
+  }),
 });
-handlers.register({
-  metaEndpoint: restateService.metaEndpoint,
-  invokerRoleArn: restateService.invokerRole.roleArn,
-  authTokenSecretArn: restateService.authToken.secretArn,
+
+const handlers = new restate.LambdaServiceRegistry(scope, "ServiceRegistry", {
+  environment,
+  handlers: {
+    "namespace.Service": service,
+    // ...additional handlers as needed
+  },
 });
 ```
 </TabItem>
@@ -154,7 +151,9 @@ handlers.register({
 
 You can use the following examples as references for your own CDK projects:
 
-- [hello-world-lambda-cdk](https://github.com/restatedev/examples/tree/main/kotlin/hello-world-lambda-cdk) - provides a
-  simple example of a Lambda-deployed Kotlin handler
+- [hello-world-lambda-cdk (Kotlin)](https://github.com/restatedev/examples/tree/main/kotlin/hello-world-lambda-cdk) -
+  provides a simple example of a Lambda-deployed Kotlin handler with a CDK stack modeled in TypeScript
+- [hello-world-lambda-cdk (TypeScript)](https://github.com/restatedev/examples/tree/main/typescript/hello-world-lambda-cdk) -
+  provides a simple example of a Lambda-deployed TypeScript handler with a CDK stack modeled in TypeScript
 - [Restate Holiday](https://github.com/restatedev/restate-holiday) - a more complex example of a fictional reservation
-  service demonstrating the Saga orchestration pattern
+  service demonstrating the Saga orchestration pattern across multiple Restate services implemented in TypeScript

--- a/docs/services/deployment/cdk.mdx
+++ b/docs/services/deployment/cdk.mdx
@@ -86,7 +86,7 @@ Restate server in the same or separate CDK stack.
 See [Deploying Restate on Amazon EC2 with CDK](/restate/deployment#amazon-ec2-with-cdk) for more information on how to
 deploy Restate itself in your own CDK stack.
 
-### Register Lambda-deployed services with a Restate environment
+### Register Lambda handlers with Restate
 
 To enable our Lambda handlers to receive Restate requests, we need to create a deployment with Restate.
 The `LambdaServiceRegistry` construct represents a collection of Lambda-backed Restate services and takes


### PR DESCRIPTION
- keep up with the `@restatedev/restate-cdk` API changes introduced in 0.7.0
- adds a link to the newly-added TypeScript hello-world-lambda-cdk example