### PR TITLE
Make it more explicit how to install the Restate server

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -14,8 +14,9 @@ This guide takes you through your first steps with Restate.
 - Build tools for your programming language:
     - TypeScript: Latest stable version of [NodeJS](https://nodejs.org/en/) >= v18.17.1 and [npm CLI](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= 9.6.7
     - Java: [JDK](https://whichjdk.com/) >= 17
-- [Docker](https://docs.docker.com/engine/install/) to run Restate
-- (Optional): Restate CLI: [Installation guide](/restate/cli#installation)
+- [Install Restate server](https://restate.dev/get-restate/)
+    - For running the Docker image, you need to [install Docker](https://docs.docker.com/engine/install/)
+- [Install Restate CLI](/restate/cli#installation) (optional)
 
 ## Step 1: Scaffold the project
 
@@ -111,10 +112,7 @@ docker run --name restate_dev --rm -d --network=host docker.io/restatedev/restat
 ```
 
 :::tip
-Restate is a single self-contained binary and Docker just one of the ways to run it. You can also obtain the binary from the
-[releases page](https://github.com/restatedev/restate/releases), from our [Homebrew tap](https://github.com/restatedev/homebrew-tap)
-with `brew install restatedev/tap/restate`, or from [npm](https://www.npmjs.com/package/@restatedev/restate-server)
-with `npm install @restatedev/restate-server`.
+Restate is a single self-contained binary and Docker just one of the ways to run it. Check out our [download page](https://restate.dev/get-restate/) for how to install the binary via Homebrew and npm.
 :::
 
 Register the service:
@@ -147,10 +145,7 @@ docker run --name restate_dev --rm -d -p 8080:8080 -p 9070-9071:9070-9071 docker
 ```
 
 :::tip
-Restate is a single self-contained binary and Docker just one of the ways to run it. You can also obtain the binary from the
-[releases page](https://github.com/restatedev/restate/releases), from our [Homebrew tap](https://github.com/restatedev/homebrew-tap)
-with `brew install restatedev/tap/restate`, or from [npm](https://www.npmjs.com/package/@restatedev/restate-server)
-with `npm install @restatedev/restate-server`.
+Restate is a single self-contained binary and Docker just one of the ways to run it. Check out our [download page](https://restate.dev/get-restate/) for how to install the binary via Homebrew and npm.
 :::
 
 Register the services:

--- a/docs/restate/cli.mdx
+++ b/docs/restate/cli.mdx
@@ -6,7 +6,7 @@ description: "Use the CLI to interact with Restate."
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# CLI 
+# CLI
 
 You can use the CLI to interact with Restate, and manage your services, deployments and invocations.
 
@@ -15,10 +15,10 @@ You can use the CLI to interact with Restate, and manage your services, deployme
 Install the Restate CLI via:
 
 <Tabs groupId="operating-systems">
-<TabItem value="lin" label="npm">
+<TabItem value="lin" label="npx">
 
 ```shell
-npm i @restatedev/restate
+npm install --global @restatedev/restate
 ```
 
 </TabItem>
@@ -74,7 +74,7 @@ restate whoami
 
 **Printing help**
 
-```shell 
+```shell
 restate --help
 ```
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,6 +99,11 @@ const config = {
             position: "right",
           },
           {
+            to: "https://restate.dev/get-restate/",
+            label: "Get Restate",
+            position: "right",
+          },
+          {
             href: "https://discord.gg/skW3AZ6uGd",
             html: '<svg xmlns="http://www.w3.org/2000/svg" width="25" height="20" fill="none" stroke="currentColor" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"  viewBox="0 0 127.14 96.36"><g id="图层_2" data-name="图层 2"><g id="Discord_Logos" data-name="Discord Logos"><g id="Discord_Logo_-_Large_-_White" data-name="Discord Logo - Large - White"><path d="M107.7,8.07A105.15,105.15,0,0,0,81.47,0a72.06,72.06,0,0,0-3.36,6.83A97.68,97.68,0,0,0,49,6.83,72.37,72.37,0,0,0,45.64,0,105.89,105.89,0,0,0,19.39,8.09C2.79,32.65-1.71,56.6.54,80.21h0A105.73,105.73,0,0,0,32.71,96.36,77.7,77.7,0,0,0,39.6,85.25a68.42,68.42,0,0,1-10.85-5.18c.91-.66,1.8-1.34,2.66-2a75.57,75.57,0,0,0,64.32,0c.87.71,1.76,1.39,2.66,2a68.68,68.68,0,0,1-10.87,5.19,77,77,0,0,0,6.89,11.1A105.25,105.25,0,0,0,126.6,80.22h0C129.24,52.84,122.09,29.11,107.7,8.07ZM42.45,65.69C36.18,65.69,31,60,31,53s5-12.74,11.43-12.74S54,46,53.89,53,48.84,65.69,42.45,65.69Zm42.24,0C78.41,65.69,73.25,60,73.25,53s5-12.74,11.44-12.74S96.23,46,96.12,53,91.08,65.69,84.69,65.69Z"/></g></g></g></svg>',
             position: "right",


### PR DESCRIPTION
This commit tries to improve how the Restate server can be installed. Moreover, it replaces npm i @restatedev/restate with npx @restatedev/restate since npm i does not allow one to run the binary. An alternative could have been to globally install the @restatedev/restate package which makes the contained binary available on the `PATH`.