### PR TITLE
Adjust documentation for splitting context in context and objectcontext

### DIFF
--- a/docs/services/invocation.mdx
+++ b/docs/services/invocation.mdx
@@ -47,7 +47,7 @@ For example, for a keyed service `greeter-service` with the following implementa
 
 ```ts
 const router = restate.keyedRouter({
-    greet: async (ctx: restate.RpcContext, name: string, req: { age: number } ) => {
+    greet: async (ctx: restate.KeyedContext, name: string, req: { age: number } ) => {
         return `Hello ${name} of ${req.age} years old`;
     },
 });

--- a/docs/services/sdk/kafka.mdx
+++ b/docs/services/sdk/kafka.mdx
@@ -38,7 +38,7 @@ You can handle events within keyed routers, where the key of the Kafka record ma
 import * as restate from "@restatedev/restate-sdk";
 
 const router = restate.keyedRouter({
-    eventHandler: restate.keyedEventHandler(async (ctx: restate.RpcContext, event: restate.Event) => {
+    eventHandler: restate.keyedEventHandler(async (ctx: restate.KeyedContext, event: restate.Event) => {
         // Extract event payload as json
         const { myData } = event.json<{ myData: string }>();
         // OR extract event payload as raw bytes and deserialize it
@@ -109,7 +109,7 @@ import Empty from "./generated/google/protobuf/empty";
 
 export class MyServiceImpl implements MyService {
     async handleEvent(request: MyEvent): Promise<Empty> {
-      const ctx = restate.useContext(this);
+      const ctx = restate.useKeyedContext(this);
       const payload = request.payload;
 
       // Handle event
@@ -177,7 +177,7 @@ service MyService {
     rpc MyMethod(MyMethodRequest) returns (google.protobuf.Empty);
 
     // Event handler method
-    rpc HandleEvent(MyEvent) returns (google.protobuf.Empty);
+    rpc Handle(MyEvent) returns (google.protobuf.Empty);
 }
 
 message MyMethodRequest {
@@ -199,7 +199,7 @@ message MyEvent {
 import dev.restate.generated.MyEvent;
 
 @Override
-public void handle(RestateContext ctx, MyEvent event) {
+public void handle(ObjectContext ctx, MyEvent event) {
 
     // Do something with event
 }

--- a/docs/services/sdk/overview.mdx
+++ b/docs/services/sdk/overview.mdx
@@ -112,7 +112,7 @@ This example shows a greeter service comprising two methods:
 
 ```typescript
 const router = restate.keyedRouter({
-    greet: async (ctx: restate.Context, name: string) => {
+    greet: async (ctx: restate.KeyedContext, name: string) => {
         return `Hello ${name}!`;
     },
     countGreetings: async (ctx: restate.KeyedContext, name: string) => {
@@ -134,11 +134,10 @@ restate
 ```
 
 The app logic is implemented inside the `greet` and `countGreetings` functions.
-The `restate.Context` is supplied as the first argument.
+The `restate.KeyedContext` is supplied as the first argument.
 The [Restate context](/services/sdk/restate-context) enables interaction with Restate (call other methods, retrieve state, etc.).
-The `countGreetings` function uses the `restate.KeyedContext` because it needs access to the K/V state stored in Restate.
-The KeyedContext makes sure that invocations are sequenced per key. So there is at most one ongoing invocation for a specific key.
-This guarantees that at most one function is changing the state for a specific key.
+The `countGreetings` function uses the `restate.KeyedContext` because it belongs to a keyed service.
+For unkeyed services, you would use `restate.Context`.
 
 Finally, the Restate server is set up to serve both functions.
 The service is registered as a keyed service under the path `greeter`, and the `greet` and `countGreetings` routes are added.
@@ -170,7 +169,7 @@ import {
 export class GreeterService implements Greeter {
     async greet(request: GreetRequest): Promise<GreetResponse> {
         // Retrieving the Restate context
-        const ctx = restate.useContext(this);
+        const ctx = restate.useKeyedContext(this);
         return GreetResponse.create({ greeting: `Hello ${request.name}` });
     }
 
@@ -204,7 +203,7 @@ restate
 
 The interface of the gRPC service is defined in the [Protobuf](https://protobuf.dev/) service contracts, that are shown below.
 Within the method, the Restate context is retrieved, enabling interaction with Restate (e.g. calling other services).
-For keyed services, where we want to sequence invocations per key or have access to K/V state, you use the KeyedContext as shown in the `countGreetings` function.
+For keyed services, you use the `restate.KeyedContext`. For unkeyed services, instead, you use the `restate.Context`.
 Finally, the Restate server is set up to serve both methods of the greeter service.
 
 This is what corresponding Protobuf definition would look like for this service:
@@ -278,7 +277,7 @@ It has the name of the service (`Greeter`) with `Restate` appended to it.
 
 The [Restate context](/services/sdk/restate-context) is supplied to the method as the first argument.
 The context enables interaction with Restate (e.g. calling other services, setting timers).
-The `greet` method uses an ObjectContext since it uses Restate's K/V state, so it needs invocations to be sequenced per key, to avoid state inconsistencies when multiple functions would be writing to the same state key.
+The `greet` method uses an ObjectContext since it is a keyed service. For unkeyed services, use `Context`.
 Finally, the Restate server is set up to serve both methods of the greeter service.
 
 This is what corresponding Protobuf definition would look like for this service:

--- a/docs/services/sdk/overview.mdx
+++ b/docs/services/sdk/overview.mdx
@@ -112,10 +112,10 @@ This example shows a greeter service comprising two methods:
 
 ```typescript
 const router = restate.keyedRouter({
-    greet: async (ctx: restate.RpcContext, name: string) => {
+    greet: async (ctx: restate.Context, name: string) => {
         return `Hello ${name}!`;
     },
-    countGreetings: async (ctx: restate.RpcContext, name: string) => {
+    countGreetings: async (ctx: restate.KeyedContext, name: string) => {
         // Retrieve state; number of times this name was seen
         let seen = await ctx.get<number>("seen") || 0;
         seen += 1;
@@ -134,8 +134,11 @@ restate
 ```
 
 The app logic is implemented inside the `greet` and `countGreetings` functions.
-The `restate.RpcContext` is supplied as the first argument.
+The `restate.Context` is supplied as the first argument.
 The [Restate context](/services/sdk/restate-context) enables interaction with Restate (call other methods, retrieve state, etc.).
+The `countGreetings` function uses the `restate.KeyedContext` because it needs access to the K/V state stored in Restate.
+The KeyedContext makes sure that invocations are sequenced per key. So there is at most one ongoing invocation for a specific key.
+This guarantees that at most one function is changing the state for a specific key.
 
 Finally, the Restate server is set up to serve both functions.
 The service is registered as a keyed service under the path `greeter`, and the `greet` and `countGreetings` routes are added.
@@ -166,12 +169,14 @@ import {
 // Implementation of the gRPC service
 export class GreeterService implements Greeter {
     async greet(request: GreetRequest): Promise<GreetResponse> {
+        // Retrieving the Restate context
+        const ctx = restate.useContext(this);
         return GreetResponse.create({ greeting: `Hello ${request.name}` });
     }
 
     async countGreetings(request: GreetRequest): Promise<GreetResponse> {
         // Retrieving the Restate context
-        const ctx = restate.useContext(this);
+        const ctx = restate.useKeyedContext(this);
 
         // Retrieve state; number of times this name was seen
         let seen = (await ctx.get<number>("seen")) || 0;
@@ -198,7 +203,8 @@ restate
 ```
 
 The interface of the gRPC service is defined in the [Protobuf](https://protobuf.dev/) service contracts, that are shown below.
-Within the method, the Restate context is retrieved, enabling interaction with Restate (e.g. getting state, calling other services).
+Within the method, the Restate context is retrieved, enabling interaction with Restate (e.g. calling other services).
+For keyed services, where we want to sequence invocations per key or have access to K/V state, you use the KeyedContext as shown in the `countGreetings` function.
 Finally, the Restate server is set up to serve both methods of the greeter service.
 
 This is what corresponding Protobuf definition would look like for this service:
@@ -240,7 +246,7 @@ Restate uses [protobuf](https://protobuf.dev/) to define the service and its met
 ```java
 package dev.restate.sdk.examples;
 
-import dev.restate.sdk.blocking.RestateContext;
+import dev.restate.sdk.ObjectContext;
 import dev.restate.sdk.core.CoreSerdes;
 import dev.restate.sdk.core.StateKey;
 import dev.restate.sdk.examples.generated.*;
@@ -253,7 +259,7 @@ public class Greeter extends GreeterRestate.GreeterRestateImplBase {
   private static final StateKey<Integer> COUNT = StateKey.of("count", CoreSerdes.INT);
 
   @Override
-  public GreetResponse greet(RestateContext ctx, GreetRequest request) {
+  public GreetResponse greet(ObjectContext ctx, GreetRequest request) {
     int count = ctx.get(COUNT).orElse(1);
     ctx.set(COUNT, count + 1);
 
@@ -271,7 +277,8 @@ The `Greeter` class extends `GreeterRestate.GreeterRestateImplBase`, which is th
 It has the name of the service (`Greeter`) with `Restate` appended to it.
 
 The [Restate context](/services/sdk/restate-context) is supplied to the method as the first argument.
- The context enables interaction with Restate (e.g. getting state, calling other services).
+The context enables interaction with Restate (e.g. calling other services, setting timers).
+The `greet` method uses an ObjectContext since it uses Restate's K/V state, so it needs invocations to be sequenced per key, to avoid state inconsistencies when multiple functions would be writing to the same state key.
 Finally, the Restate server is set up to serve both methods of the greeter service.
 
 This is what corresponding Protobuf definition would look like for this service:
@@ -314,22 +321,22 @@ An example:
 ```java
 package dev.restate.sdk.examples;
 
-import dev.restate.sdk.blocking.RestateBlockingService;
-import dev.restate.sdk.blocking.RestateContext;
-import dev.restate.sdk.core.StateKey;
+import dev.restate.sdk.Component;
+import dev.restate.sdk.ObjectContext;
+import dev.restate.sdk.common.StateKey;
 import dev.restate.sdk.common.CoreSerdes;
 import dev.restate.sdk.examples.generated.*;
 import dev.restate.sdk.http.vertx.RestateHttpEndpointBuilder;
 import io.grpc.stub.StreamObserver;
 import static dev.restate.sdk.examples.generated.GreeterProto.*;
 
-public class Greeter extends GreeterGrpc.GreeterImplBase implements RestateService {
+public class Greeter extends GreeterGrpc.GreeterImplBase implements Component {
 
   private static final StateKey<Integer> COUNT = StateKey.of("count", CoreSerdes.INT);
 
   @Override
   public void greet(GreetRequest request, StreamObserver<GreetResponse> responseObserver) {
-    RestateContext ctx = restateContext();
+    ObjectContext ctx = ObjectContext.current();
 
     int count = ctx.get(COUNT).orElse(1);
     ctx.set(COUNT, count + 1);

--- a/docs/services/sdk/restate-context.mdx
+++ b/docs/services/sdk/restate-context.mdx
@@ -17,6 +17,8 @@ You can retrieve the context object as follows:
 <Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript" default>
 
+For unkeyed routers:
+
 ```typescript
 import * as restate from "@restatedev/restate-sdk";
 
@@ -26,11 +28,7 @@ const greet = async (ctx: restate.Context, name: string) => {
 };
 ```
 
-The Restate context is supplied as the first argument `ctx` to the handler.
-The arguments behind that are optional. For more information on the handler signature, have a look at the [serving docs](/services/sdk/serving).
-
-If you use a keyed service, and you want your invocations to be keyed, you need to use the keyed context.
-This is required to use Restate's K/V state store.
+For keyed routers:
 
 ```typescript
 import * as restate from "@restatedev/restate-sdk";
@@ -41,9 +39,13 @@ const greet = async (ctx: restate.KeyedContext, name: string) => {
 };
 ```
 
+The Restate context is supplied as the first argument `ctx` to the handler.
+The arguments behind that are optional. For more information on the handler signature, have a look at the [serving docs](/services/sdk/serving).
+
 </TabItem>
 <TabItem value="ts-grpc" label="TypeScript-gRPC">
 
+For unkeyed routers:
 
 ```typescript
 import * as restate from "@restatedev/restate-sdk";
@@ -55,8 +57,7 @@ async greet(request: Request): Promise<Response> {
 }
 ```
 
-If you use a keyed service, and you want your invocations to be keyed, you need to use the keyed context.
-This is required to use Restate's K/V state store.
+For keyed routers:
 
 ```typescript
 import * as restate from "@restatedev/restate-sdk";
@@ -74,7 +75,7 @@ async greet(request: Request): Promise<Response> {
 
 The Restate context is supplied as the first argument `ctx` to the method.
 
-For example:
+For unkeyed services:
 
 ```java
 public class Greeter extends GreeterRestate.GreeterRestateImplBase {
@@ -86,8 +87,7 @@ public class Greeter extends GreeterRestate.GreeterRestateImplBase {
 }
 ```
 
-If you use a keyed service, and you want your invocations to be keyed, you need to use the object context.
-This is required to use Restate's K/V state store.
+For keyed services:
 
 ```java
 public class Greeter extends GreeterRestate.GreeterRestateImplBase {
@@ -106,7 +106,9 @@ Have a look at the [Context JavaDocs](https://javadoc.io/doc/dev.restate/sdk-api
 <details>
 <summary>Alternative: vanilla gRPC</summary>
 
-If you do not use Restate's generated protobuf code, you can access the restate context as follows:
+If you do not use Restate's generated protobuf code, you can access the restate context as follows.
+
+For unkeyed services:
 
 ```java
 import dev.restate.sdk.Context;
@@ -115,7 +117,7 @@ import dev.restate.sdk.Context;
 Context ctx = Context.current();
 ```
 
-For the keyed context, do:
+For keyed services:
 
 ```java
 import dev.restate.sdk.ObjectContext;
@@ -139,12 +141,4 @@ All method calls made through the Restate context are durably stored in the exec
 and can be replayed in case of failure, ensuring that your service is always reliable and fault-tolerant.
 This means that if you do actions (e.g. calling other services, sleep) without making use of the Restate SDK,
 you do not have these benefits.
-:::
-
-:::danger
-If you want to have at most one ongoing invocation per key (e.g. when interacting with state),
-make sure you use the ObjectContext (for Java) or KeyedContext (for TypeScript).
-The ObjectContext makes sure that invocations are sequenced per key. So there is at most one ongoing invocation for a specific key.
-This guarantees that at most one function is changing the state for a specific key.
-This is required to prevent inconsistent state when multiple invocations would be writing to the same key.
 :::

--- a/docs/services/sdk/restate-context.mdx
+++ b/docs/services/sdk/restate-context.mdx
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 # Restate context
 
-In Restate services, all interaction with the runtime occur through the Restate context.
+In Restate services, all interaction with the runtime occurs through the Restate context.
 This context provides a set of methods that allow you to perform actions such as getting or setting state, or
 calling other services.
 
@@ -20,7 +20,7 @@ You can retrieve the context object as follows:
 ```typescript
 import * as restate from "@restatedev/restate-sdk";
 
-const greet = async (ctx: restate.RpcContext, name: string) => {
+const greet = async (ctx: restate.Context, name: string) => {
 
     //...the rest of your code...
 };
@@ -28,6 +28,18 @@ const greet = async (ctx: restate.RpcContext, name: string) => {
 
 The Restate context is supplied as the first argument `ctx` to the handler.
 The arguments behind that are optional. For more information on the handler signature, have a look at the [serving docs](/services/sdk/serving).
+
+If you use a keyed service, and you want your invocations to be keyed, you need to use the keyed context.
+This is required to use Restate's K/V state store.
+
+```typescript
+import * as restate from "@restatedev/restate-sdk";
+
+const greet = async (ctx: restate.KeyedContext, name: string) => {
+
+    //...the rest of your code...
+};
+```
 
 </TabItem>
 <TabItem value="ts-grpc" label="TypeScript-gRPC">
@@ -43,6 +55,19 @@ async greet(request: Request): Promise<Response> {
 }
 ```
 
+If you use a keyed service, and you want your invocations to be keyed, you need to use the keyed context.
+This is required to use Restate's K/V state store.
+
+```typescript
+import * as restate from "@restatedev/restate-sdk";
+
+async greet(request: Request): Promise<Response> {
+    const ctx = restate.useKeyedContext(this);
+
+    //...the rest of your code...
+};
+```
+
 </TabItem>
 
 <TabItem value="java" label="Java">
@@ -55,26 +80,48 @@ For example:
 public class Greeter extends GreeterRestate.GreeterRestateImplBase {
 
   @Override
-  public GreetResponse greet(RestateContext ctx, GreetRequest request) {
+  public GreetResponse greet(Context ctx, GreetRequest request) {
     // implement your method
   }
 }
 ```
 
+If you use a keyed service, and you want your invocations to be keyed, you need to use the object context.
+This is required to use Restate's K/V state store.
+
+```java
+public class Greeter extends GreeterRestate.GreeterRestateImplBase {
+
+    @Override
+    public GreetResponse greet(ObjectContext ctx, GreetRequest request) {
+        // implement your method
+    }
+}
+```
+
 :::note
-Have a look at the [JavaDocs](https://javadoc.io/doc/dev.restate/sdk-api/latest/dev/restate/sdk/RestateContext.html) for an overview of what you can do with the Restate context.
+Have a look at the [Context JavaDocs](https://javadoc.io/doc/dev.restate/sdk-api/latest/dev/restate/sdk/Context.html) and [ObjectContext JavaDocs](https://javadoc.io/doc/dev.restate/sdk-api/latest/dev/restate/sdk/ObjectContext.html) for an overview of what you can do with the Restate context.
 :::
 
 <details>
 <summary>Alternative: vanilla gRPC</summary>
 
-If you do not use Restate's generated protobuf code, you can access the restate context as follows
+If you do not use Restate's generated protobuf code, you can access the restate context as follows:
 
 ```java
-import dev.restate.sdk.blocking.RestateContext;
+import dev.restate.sdk.Context;
 
 // Inside your method:
-RestateContext ctx = restateContext();
+Context ctx = Context.current();
+```
+
+For the keyed context, do:
+
+```java
+import dev.restate.sdk.ObjectContext;
+
+// Inside your method:
+ObjectContext ctx = ObjectContext.current();
 ```
 
 </details>
@@ -92,4 +139,12 @@ All method calls made through the Restate context are durably stored in the exec
 and can be replayed in case of failure, ensuring that your service is always reliable and fault-tolerant.
 This means that if you do actions (e.g. calling other services, sleep) without making use of the Restate SDK,
 you do not have these benefits.
+:::
+
+:::danger
+If you want to have at most one ongoing invocation per key (e.g. when interacting with state),
+make sure you use the ObjectContext (for Java) or KeyedContext (for TypeScript).
+The ObjectContext makes sure that invocations are sequenced per key. So there is at most one ongoing invocation for a specific key.
+This guarantees that at most one function is changing the state for a specific key.
+This is required to prevent inconsistent state when multiple invocations would be writing to the same key.
 :::

--- a/docs/services/sdk/service-communication.mdx
+++ b/docs/services/sdk/service-communication.mdx
@@ -23,7 +23,7 @@ On the side of the service that you are going to call, you export the API defini
 
 ```ts
 const greeterRouter = restate.router({
-  greet:    async(ctx: restate.RpcContext, name: string) => { ... }
+  greet:    async(ctx: restate.Context, name: string) => { ... }
 });
 
 // Option 1: export only the type signature of the router

--- a/docs/services/sdk/serving.mdx
+++ b/docs/services/sdk/serving.mdx
@@ -26,8 +26,8 @@ For **unkeyed services**, the router looks as follows:
 ```typescript
 const serviceRouter = restate.router({
     hello: async () => { ... },
-    callMe: async (ctx: restate.RpcContext) => { ... },
-    maybe: async (ctx: restate.RpcContext, request: Request) => { ... }
+    callMe: async (ctx: restate.Context) => { ... },
+    maybe: async (ctx: restate.Context, request: Request) => { ... }
 });
 ```
 
@@ -36,7 +36,7 @@ This means that the `hello` function can be called via `<RESTATE_INGRESS_URL>/my
 
 The functions of an unkeyed router have two optional parameters:
 
-- A `ctx` of type `restate.RpcContext` which allows to interact with Restate.
+- A `ctx` of type `restate.Context` which allows to interact with Restate.
 - A `request` of type JSON object that represents additional invocation data.
 
 The parameter names may be chosen differently.
@@ -46,9 +46,9 @@ For **keyed services**, the router looks as follows:
 // 2. Create a router for keyed services (if any):
 const keyedServiceRouter = restate.keyedRouter({
     hello: async () => { ... },
-    callMe: async (ctx: restate.RpcContext) => { ... },
-    maybe: async (ctx: restate.RpcContext, key: string) => { ... },
-    withSomething: async (ctx: restate.RpcContext, key: string, request: Request) => { ... }
+    callMe: async (ctx: restate.KeyedContext) => { ... },
+    maybe: async (ctx: restate.Context, key: string) => { ... },
+    withSomething: async (ctx: restate.Context, key: string, request: Request) => { ... }
 });
 ```
 
@@ -57,7 +57,8 @@ This means that the `hello` function can be called via `<RESTATE_INGRESS_URL>/my
 
 The functions of a keyed router have three optional parameters:
 
-- A `ctx` of type `restate.RpcContext` which allows to interact with Restate.
+- A `ctx` of type `restate.Context` which allows to interact with Restate.
+If you need access to K/V state or want to sequence invocations per key (at most one ongoing invocation per key), then use the `restate.KeyedContext`.
 - A `key` parameter of type string which represents the key of the invoked service.
 - A `request` parameter of type JSON object which represents additional invocation data.
 

--- a/docs/services/sdk/serving.mdx
+++ b/docs/services/sdk/serving.mdx
@@ -47,8 +47,8 @@ For **keyed services**, the router looks as follows:
 const keyedServiceRouter = restate.keyedRouter({
     hello: async () => { ... },
     callMe: async (ctx: restate.KeyedContext) => { ... },
-    maybe: async (ctx: restate.Context, key: string) => { ... },
-    withSomething: async (ctx: restate.Context, key: string, request: Request) => { ... }
+    maybe: async (ctx: restate.KeyedContext, key: string) => { ... },
+    withSomething: async (ctx: restate.KeyedContext, key: string, request: Request) => { ... }
 });
 ```
 
@@ -57,8 +57,8 @@ This means that the `hello` function can be called via `<RESTATE_INGRESS_URL>/my
 
 The functions of a keyed router have three optional parameters:
 
-- A `ctx` of type `restate.Context` which allows to interact with Restate.
-If you need access to K/V state or want to sequence invocations per key (at most one ongoing invocation per key), then use the `restate.KeyedContext`.
+- A `ctx` of type `restate.KeyedContext` which allows to interact with Restate.
+The `restate.KeyedContext` allows the same operations as the `restate.Context` but is enriched with the extra functionality for keyed services (e.g. access to K/V state).
 - A `key` parameter of type string which represents the key of the invoked service.
 - A `request` parameter of type JSON object which represents additional invocation data.
 

--- a/docs/services/sdk/side-effects.mdx
+++ b/docs/services/sdk/side-effects.mdx
@@ -191,7 +191,7 @@ You can throw a terminal exception via `dev.restate.sdk.core.TerminalException` 
 
   @Override
   public void myMethod(Request request, StreamObserver<Empty> responseObserver) {
-    RestateContext ctx = restateContext();
+    Context ctx = Context.current();
 
     //highlight-start
     try {

--- a/docs/tour.mdx
+++ b/docs/tour.mdx
@@ -377,15 +377,15 @@ You specify an unkeyed service by creating a router with its set of functions.
 
 ```typescript
 const serviceRouter = restate.router({
-    hello: async (ctx: restate.RpcContext, request: Request) => { ... },
-    callMe: async (ctx: restate.RpcContext) => { ... },
+    hello: async (ctx: restate.Context, request: Request) => { ... },
+    callMe: async (ctx: restate.Context) => { ... },
     maybe: async () => { ... }
 });
 ```
 
 The functions of an unkeyed router have two optional parameters:
 
-* A `ctx` of type `restate.RpcContext` which allows to interact with Restate.
+* A `ctx` of type `restate.Context` which allows to interact with Restate.
 * A `request` of type JSON object which represents additional invocation data.
 
 You can choose the parameter names differently.
@@ -394,7 +394,7 @@ For example, for the `Checkout` service, you create a router with the `checkout`
 
 ```typescript
 const checkout = async (
-    ctx: restate.RpcContext,
+    ctx: restate.KeyedContext,
     request: { userId: string; tickets: string[] },
 ) => {
     return true;
@@ -414,16 +414,17 @@ You specify a keyed service by creating a keyed router with its set of functions
 
 ```typescript
 const keyedServiceRouter = restate.keyedRouter({
-  hello: async (ctx: restate.RpcContext, key: string, request: Request) => { ... },
-  callMe: async (ctx: restate.RpcContext, key: string) => { ... },
-  maybe: async (ctx: restate.RpcContext) => { ... },
+  hello: async (ctx: restate.KeyedContext, key: string, request: Request) => { ... },
+  callMe: async (ctx: restate.Context, key: string) => { ... },
+  maybe: async (ctx: restate.Context) => { ... },
   withSomething: async () => { ... }
 });
 ```
 
 The functions of a keyed router have three optional parameters
 
-* A `ctx` of type `restate.RpcContext` which allows to interact with Restate.
+* A `ctx` of type `restate.Context` which allows to interact with Restate.
+If you need access to K/V state or want to sequence invocations per key (at most one ongoing invocation per key), then use the `restate.KeyedContext`.
 * A `key` parameter of type string which represents the key of the invoked service.
 * A `request` parameter of type JSON object which represents additional invocation data.
 
@@ -534,7 +535,7 @@ import * as restate from "@restatedev/restate-sdk";
 import { ticketServiceApi } from "./ticket_service";
 
 const addTicket = async (
-  ctx: restate.RpcContext,
+  ctx: restate.KeyedContext,
   userId: string,
   ticketId: string,
 ) => {
@@ -544,7 +545,7 @@ const addTicket = async (
 };
 ```
 
-To make the call, you supply the exported `ticketServiceApi` to the RpcContext via the `rpc` function to specify which service to invoke.
+To make the call, you supply the exported `ticketServiceApi` to the context via the `rpc` function to specify which service to invoke.
 Then you call the `reserve` function, which returns a Promise that gets resolved with the `boolean` response.
 
 Try it out by running the services via `npm run app` and send a request to `UserSession/addTicket`, as we did [previously](#calling-services-from-outside-restate).
@@ -577,7 +578,7 @@ To also log the messages, use `RESTATE_DEBUG_LOGGING=JOURNAL_VERBOSE`.
 
 ```java
 @Override
-public BoolValue addTicket(RestateContext ctx, ReserveTicket request) throws TerminalException {
+public BoolValue addTicket(ObjectContext ctx, ReserveTicket request) throws TerminalException {
     //highlight-start
     var ticketClnt = TicketServiceRestate.newClient(ctx);
     var success = ticketClnt.reserve(Ticket.newBuilder().setTicketId(request.getTicketId()).build()).await();
@@ -645,7 +646,7 @@ This is not the best way to sleep in a Restate service! The Restate SDK offers a
 ```typescript
 import { setTimeout } from "timers/promises";
 
-const reserve = async (ctx: restate.RpcContext) => {
+const reserve = async (ctx: restate.KeyedContext) => {
   //bad-code-start
   await setTimeout(35000);
   //bad-code-end
@@ -688,7 +689,7 @@ Once the runtime has received the response, it invokes the `addTicket` function 
 
 ```java
 @Override
-public BoolValue reserve(RestateContext ctx, Ticket request) throws TerminalException {
+public BoolValue reserve(ObjectContext ctx, Ticket request) throws TerminalException {
   //bad-code-start
   try {
     Thread.sleep(65000);
@@ -765,7 +766,7 @@ Add the following code to the `UserSession/checkout` function:
 ```typescript
 import { checkoutApi } from "./checkout";
 
-const checkout = async (ctx: restate.RpcContext, userId: string) => {
+const checkout = async (ctx: restate.KeyedContext, userId: string) => {
   //highlight-start
   const checkoutRequest = { userId: userId, tickets: ["456"] };
   const success = await ctx.rpc(checkoutApi).checkout(checkoutRequest);
@@ -796,7 +797,7 @@ Notice that the `UserSession` didn't get suspended because the response came bef
 
 ```java
 @Override
-public BoolValue checkout(RestateContext ctx, CheckoutRequest request) throws TerminalException {
+public BoolValue checkout(ObjectContext ctx, CheckoutRequest request) throws TerminalException {
     //highlight-start
     var checkoutClnt = CheckoutRestate.newClient(ctx);
     var checkoutSuccess = checkoutClnt.checkout(
@@ -838,11 +839,11 @@ Up to now, all our service calls waited for a response. This is referred to as r
 <Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
-Update `expireTicket` to use `RpcContext.send` to send a one-way message to release the reservation:
+Update `expireTicket` to use `ctx.send` to send a one-way message to release the reservation:
 
 ```typescript
 const addTicket = async (
-    ctx: restate.RpcContext,
+    ctx: restate.KeyedContext,
     userId: string,
     ticketId: string,
 ) => {
@@ -853,7 +854,7 @@ const addTicket = async (
 };
 ```
 
-Note that `RpcContext.send` isn't an asynchronous operation which returns a promise.
+Note that `ctx.send` isn't an asynchronous operation which returns a promise.
 Therefore, there is no need to await it.
 
 Once you have adapted the code, try it out by calling the `UserSession/addTicket` function, as [explained earlier](#calling-services-from-outside-restate).
@@ -884,7 +885,7 @@ Update the reserve request in `addTicket` to use `oneWay()` to send a one-way me
 
 ```java
 @Override
-public void addTicket(RestateContext ctx, ReserveTicket request) throws TerminalException {
+public void addTicket(ObjectContext ctx, ReserveTicket request) throws TerminalException {
     var ticketClnt = TicketServiceRestate.newClient(ctx);
     //highlight-next-line
     ticketClnt.oneWay().reserve(Ticket.newBuilder().setTicketId(request.getTicketId()).build());
@@ -943,7 +944,7 @@ When you are done with the implementation, send a request to `UserSession/expire
 
 ```typescript
 const expireTicket = async (
-  ctx: restate.RpcContext,
+  ctx: restate.KeyedContext,
   userId: string,
   ticketId: string,
 ) => {
@@ -986,7 +987,7 @@ Have a look at the logs again to see what happened:
 
 ```java
 @Override
-public void expireTicket(RestateContext ctx, ExpireTicketRequest request) throws TerminalException {
+public void expireTicket(ObjectContext ctx, ExpireTicketRequest request) throws TerminalException {
     //highlight-start
     var ticketClnt = TicketServiceRestate.newClient(ctx);
     ticketClnt.oneWay().unreserve(Ticket.newBuilder().setTicketId(request.getTicketId()).build());
@@ -1050,7 +1051,7 @@ Restate offers the same mechanism for timers.
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
-const reserve = async (ctx: restate.RpcContext) => {
+const reserve = async (ctx: restate.KeyedContext) => {
   //good-code-start
   await ctx.sleep(35000);
   //good-code-end
@@ -1063,7 +1064,7 @@ const reserve = async (ctx: restate.RpcContext) => {
 
 ```java
 @Override
-public BoolValue reserve(RestateContext ctx, Ticket request) throws TerminalException {
+public BoolValue reserve(ObjectContext ctx, Ticket request) throws TerminalException {
     //good-code-start
     ctx.sleep(Duration.ofSeconds(65));
     //good-code-end
@@ -1140,11 +1141,11 @@ In `UserSession/addTicket`, revert the call to `reserve` to a request-response c
 <Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript">
 
-Replace the `RpcContext.send()` with `RpcContext.rpc()`, to end up with:
+Replace the `ctx.send()` with `ctx.rpc()`, to end up with:
 
 ```ts
 const addTicket = async (
-  ctx: restate.RpcContext,
+  ctx: restate.KeyedContext,
   userId: string,
   ticketId: string,
 ) => {
@@ -1189,7 +1190,7 @@ const addTicket = async (
 
 ```java
 @Override
-public BoolValue addTicket(RestateContext ctx, ReserveTicket request) throws TerminalException {
+public BoolValue addTicket(ObjectContext ctx, ReserveTicket request) throws TerminalException {
     // highlight-start
     var ticketClnt = TicketServiceRestate.newClient(ctx);
     var reservationSuccess = ticketClnt.reserve(Ticket.newBuilder().setTicketId(request.getTicketId()).build()).await();
@@ -1268,7 +1269,7 @@ This would make the `UserSession/addTicket` function look as follows:
 
 ```typescript
 const addTicket = async (
-  ctx: restate.RpcContext,
+  ctx: restate.KeyedContext,
   userId: string,
   ticketId: string,
 ) => {
@@ -1293,7 +1294,7 @@ const addTicket = async (
 
 ```java
 @Override
-public BoolValue addTicket(RestateContext ctx, ReserveTicket request) throws TerminalException {
+public BoolValue addTicket(ObjectContext ctx, ReserveTicket request) throws TerminalException {
     var ticketClnt = TicketServiceRestate.newClient(ctx);
     var reservationSuccess = ticketClnt
         .reserve(Ticket.newBuilder().setTicketId(request.getTicketId()).build())
@@ -1436,7 +1437,7 @@ Have a look at the highlighted code:
 
 ```ts
 const addTicket = async (
-  ctx: restate.RpcContext,
+  ctx: restate.KeyedContext,
   userId: string,
   ticketId: string) => {
 
@@ -1470,7 +1471,7 @@ public static final StateKey<Set<String>> STATE_KEY =
 //highlight-end
 
 @Override
-public BoolValue addTicket(RestateContext ctx, ReserveTicket request) throws TerminalException {
+public BoolValue addTicket(ObjectContext ctx, ReserveTicket request) throws TerminalException {
     var ticketClnt = TicketServiceRestate.newClient(ctx);
     var reservationSuccess = ticketClnt
         .reserve(Ticket.newBuilder().setTicketId(request.getTicketId()).build())
@@ -1577,7 +1578,7 @@ Also adapt the `UserSession/checkout` function, to use the tickets:
 <TabItem value="ts" label="TypeScript">
 
 ```typescript
-const checkout = async (ctx: restate.RpcContext, userId: string) => {
+const checkout = async (ctx: restate.KeyedContext, userId: string) => {
   // 1. Retrieve the tickets from state
   //highlight-next-line
   const tickets = (await ctx.get<string[]>("tickets")) ?? [];
@@ -1614,7 +1615,7 @@ const checkout = async (ctx: restate.RpcContext, userId: string) => {
 public static final StateKey<Set<String>> STATE_KEY = StateKey.of("tickets", JacksonSerdes.of(new TypeReference<>() {}));
 
 @Override
-public BoolValue checkout(RestateContext ctx, CheckoutRequest request) throws TerminalException {
+public BoolValue checkout(ObjectContext ctx, CheckoutRequest request) throws TerminalException {
     // 1. Retrieve the tickets from state
     //highlight-next-line
     var tickets = ctx.get(STATE_KEY).orElseGet(HashSet::new);
@@ -1665,7 +1666,7 @@ You have almost fully implemented the user session service. After checkout, let'
 
 ```ts
 const expireTicket = async (
-  ctx: restate.RpcContext,
+  ctx: restate.KeyedContext,
   userId: string,
   ticketId: string,
 ) => {
@@ -1678,7 +1679,7 @@ const expireTicket = async (
 
 ```java
 @Override
-public void expireTicket(RestateContext ctx, ExpireTicketRequest request) throws TerminalException {
+public void expireTicket(ObjectContext ctx, ExpireTicketRequest request) throws TerminalException {
     var ticketClnt = TicketServiceRestate.newClient(ctx);
     ticketClnt.oneWay().unreserve(Ticket.newBuilder().setTicketId(request.getTicketId()).build());
 }
@@ -1699,7 +1700,7 @@ If this is the case, then you call `TicketService/unreserve` and remove it from 
 
 ```ts
 const expireTicket = async (
-  ctx: restate.RpcContext,
+  ctx: restate.KeyedContext,
   userId: string,
   ticketId: string,
 ) => {
@@ -1731,7 +1732,7 @@ curl localhost:8080/UserSession/expireTicket \
 public static final StateKey<Set<String>> STATE_KEY = StateKey.of("tickets", JacksonSerdes.of(new TypeReference<>() {}));
 
 @Override
-public void expireTicket(RestateContext ctx, ExpireTicketRequest request) throws TerminalException {
+public void expireTicket(ObjectContext ctx, ExpireTicketRequest request) throws TerminalException {
   var tickets = ctx.get(STATE_KEY).orElseGet(HashSet::new);
 
   var removed = tickets.removeIf(s -> s.equals(request.getTicketId()));
@@ -1787,7 +1788,7 @@ Remove the sleep that you added before.
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-const reserve = async (ctx: restate.RpcContext) => {
+const reserve = async (ctx: restate.KeyedContext) => {
   const status =
     (await ctx.get<TicketStatus>("status")) ?? TicketStatus.Available;
 
@@ -1807,7 +1808,7 @@ const reserve = async (ctx: restate.RpcContext) => {
 public static final StateKey<TicketStatus> STATE_KEY = StateKey.of("status", JacksonSerdes.of(TicketStatus.class));
 
 @Override
-public BoolValue reserve(RestateContext ctx, Ticket request) throws TerminalException {
+public BoolValue reserve(ObjectContext ctx, Ticket request) throws TerminalException {
   var status = ctx.get(STATE_KEY).orElse(TicketStatus.Available);
 
   if (status.equals(TicketStatus.Available)) {
@@ -1838,7 +1839,7 @@ The function should clear the value of the `"status"` key if it's not on status 
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-const unreserve = async (ctx: restate.RpcContext) => {
+const unreserve = async (ctx: restate.KeyedContext) => {
     const status =
         (await ctx.get<TicketStatus>("status")) ?? TicketStatus.Available;
 
@@ -1853,7 +1854,7 @@ const unreserve = async (ctx: restate.RpcContext) => {
 
 ```java
 @Override
-public void unreserve(RestateContext ctx, Ticket request) throws TerminalException {
+public void unreserve(ObjectContext ctx, Ticket request) throws TerminalException {
     var status = ctx.get(STATE_KEY).orElse(TicketStatus.Available);
 
     if (!status.equals(TicketStatus.Sold)) {
@@ -1882,7 +1883,7 @@ The function should set the value of the `"status"` key to `TicketStatus.Sold` i
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-const markAsSold = async (ctx: restate.RpcContext) => {
+const markAsSold = async (ctx: restate.KeyedContext) => {
     const status =
     (await ctx.get<TicketStatus>("status")) ?? TicketStatus.Available;
 
@@ -1898,7 +1899,7 @@ const markAsSold = async (ctx: restate.RpcContext) => {
 
 ```java
 @Override
-public void markAsSold(RestateContext ctx, Ticket request) throws TerminalException {
+public void markAsSold(ObjectContext ctx, Ticket request) throws TerminalException {
     var status = ctx.get(STATE_KEY).orElse(TicketStatus.Available);
 
     if (status.equals(TicketStatus.Reserved)) {
@@ -1960,7 +1961,7 @@ Use a side effect in `Checkout/checkout` to create and store a UUID (with the [u
 import { v4 as uuid } from "uuid";
 
 const checkout = async (
-  ctx: restate.RpcContext,
+  ctx: restate.Context,
   request: { userId: string; tickets: string[] },
 ) => {
   // highlight-next-line
@@ -1976,7 +1977,7 @@ const checkout = async (
 import java.util.UUID;
 
 @Override
-public BoolValue checkout(RestateContext ctx, CheckoutFlowRequest request) throws TerminalException {
+public BoolValue checkout(Context ctx, CheckoutFlowRequest request) throws TerminalException {
     // highlight-next-line
     var idempotencyKey = ctx.sideEffect(CoreSerdes.STRING_UTF8, () -> UUID.randomUUID().toString());
     return BoolValue.of(true);
@@ -2076,7 +2077,7 @@ My idempotency key: 43ba6b58-e6f8-4bc2-8112-7c93aedf59d1
 Remove the sleep again, before you continue.
 
 :::caution
-You can't execute any RestateContext calls from within a side effect.
+You can't execute any context calls from within a side effect.
 This is invalid code.
 :::
 
@@ -2102,7 +2103,7 @@ Also return the boolean result at the end of the `checkout` function.
 
 ```typescript
 const checkout = async (
-  ctx: restate.RpcContext,
+  ctx: restate.Context,
   request: { userId: string; tickets: string[] },
 ) => {
   const idempotencyKey = await ctx.sideEffect<string>(async () => uuid());
@@ -2148,7 +2149,7 @@ Payment call succeeded for idempotency key 923d1558-bf17-4c94-b027-4cfd778049fe 
 PaymentClient paymentClient = PaymentClient.get();
 
 @Override
-public BoolValue checkout(RestateContext ctx, CheckoutFlowRequest request) throws TerminalException {
+public BoolValue checkout(Context ctx, CheckoutFlowRequest request) throws TerminalException {
     // Generate idempotency key for the stripe client
     var idempotencyKey = ctx.sideEffect(CoreSerdes.STRING_UTF8, () -> UUID.randomUUID().toString());
 
@@ -2209,7 +2210,7 @@ The `Checkout/checkout` function now looks like the following:
 
 ```ts
 const checkout = async (
-  ctx: restate.RpcContext,
+  ctx: restate.Context,
   request: { userId: string; tickets: string[] },
 ) => {
   const idempotencyKey = await ctx.sideEffect(async () => uuid());
@@ -2243,7 +2244,7 @@ PaymentClient paymentClient = PaymentClient.get();
 EmailClient emailClient = EmailClient.get();
 
 @Override
-public BoolValue checkout(RestateContext ctx, CheckoutFlowRequest request) throws TerminalException {
+public BoolValue checkout(Context ctx, CheckoutFlowRequest request) throws TerminalException {
     var idempotencyKey = ctx.sideEffect(CoreSerdes.STRING_UTF8, () -> UUID.randomUUID().toString());
 
     var totalPrice = request.getTicketsList().size() * 40.0;
@@ -2271,7 +2272,7 @@ The `UserSession/checkout` function now looks like the following:
 <TabItem value="ts" label="TypeScript">
 
 ```ts
-const checkout = async (ctx: restate.RpcContext, userId: string) => {
+const checkout = async (ctx: restate.KeyedContext, userId: string) => {
   const tickets = (await ctx.get<string[]>("tickets")) ?? [];
 
   if (tickets.length === 0) {
@@ -2301,7 +2302,7 @@ const checkout = async (ctx: restate.RpcContext, userId: string) => {
 
 ```java
 @Override
-public BoolValue checkout(RestateContext ctx, CheckoutRequest request) throws TerminalException {
+public BoolValue checkout(ObjectContext ctx, CheckoutRequest request) throws TerminalException {
     var tickets = ctx.get(STATE_KEY).orElseGet(HashSet::new);
 
     if (tickets.isEmpty()) {

--- a/docs/tour.mdx
+++ b/docs/tour.mdx
@@ -394,7 +394,7 @@ For example, for the `Checkout` service, you create a router with the `checkout`
 
 ```typescript
 const checkout = async (
-    ctx: restate.KeyedContext,
+    ctx: restate.Context,
     request: { userId: string; tickets: string[] },
 ) => {
     return true;
@@ -415,16 +415,15 @@ You specify a keyed service by creating a keyed router with its set of functions
 ```typescript
 const keyedServiceRouter = restate.keyedRouter({
   hello: async (ctx: restate.KeyedContext, key: string, request: Request) => { ... },
-  callMe: async (ctx: restate.Context, key: string) => { ... },
-  maybe: async (ctx: restate.Context) => { ... },
+  callMe: async (ctx: restate.KeyedContext, key: string) => { ... },
+  maybe: async (ctx: restate.KeyedContext) => { ... },
   withSomething: async () => { ... }
 });
 ```
 
 The functions of a keyed router have three optional parameters
 
-* A `ctx` of type `restate.Context` which allows to interact with Restate.
-If you need access to K/V state or want to sequence invocations per key (at most one ongoing invocation per key), then use the `restate.KeyedContext`.
+* A `ctx` of type `restate.KeyedContext` which allows to interact with Restate.
 * A `key` parameter of type string which represents the key of the invoked service.
 * A `request` parameter of type JSON object which represents additional invocation data.
 


### PR DESCRIPTION
Fixes #301 
We now have a `Context` for shared access and an `ObjectContext` for sequenced access.
This PR changes the documentation related to this.