### PR TITLE
Document `ctx.clearAll()` and `ctx.stateKeys()`

### DIFF
--- a/docs/services/sdk/state.mdx
+++ b/docs/services/sdk/state.mdx
@@ -10,6 +10,13 @@ import TabItem from '@theme/TabItem';
 Restate offers durable storage of application state, with support for key-value state that can be retrieved, set, and cleared via its key.
 Using this feature requires no additional setup.
 
+## Listing state keys
+To list all the keys that have entries in the state store for that invocation (and its keyed service instance),, do:
+
+```
+ctx.stateKeys();
+```
+
 ## Retrieving state
 To retrieve state in Restate, you can do the following:
 
@@ -126,3 +133,9 @@ Have a look at [the docs on retrieving state](/services/sdk/state#retrieving-sta
 
 </TabItem>
 </Tabs>
+
+To delete all K/V state entries for the invocation (and its keyed service instance), do:
+
+```
+ctx.clearAll();
+```


### PR DESCRIPTION
Fixes #308 
- Documents `ctx.clearAll()`
- Documents `ctx.stateKeys()`