### PR TITLE
Document new CLI commands and add Local Dev page

### DIFF
--- a/docs/deploy/cloud.md
+++ b/docs/deploy/cloud.md
@@ -27,7 +27,7 @@ characters or hyphens. For example, you can choose `dev` for your account and
 `my-environment` for your environment.
 </Admonition>
 
-You can start using your new environment straight away using the [CLI](/operate/cli):
+You can start using your new environment straight away using the [CLI](/develop/local_dev#install-restate-server--cli):
 
 ```bash
 # authenticate to Cloud
@@ -41,7 +41,7 @@ restate whoami
 <Admonition type="tip" title="Switching environments in the CLI">
 At any time, you can switch your CLI back to point to a Restate server running
 on your machine with `restate config use-environment local`. See the
-[CLI docs](/operate/cli#using-the-config-file) for more.
+[CLI docs](/operate/configuration/cli#using-the-config-file) for more.
 </Admonition>
 
 ## Registering Restate services with your environment

--- a/docs/deploy/overview.md
+++ b/docs/deploy/overview.md
@@ -18,10 +18,10 @@ This page describes how to deploy Restate and Restate services.
 The Restate Server is a single binary that contains everything you need to host an environment. See the [Get Restate](https://restate.dev/get-restate/) page for various ways of obtaining it.
 
 There are a few options for hosting the Restate Server:
-
 - [Self-host on AWS](/deploy/lambda/self-hosted)
 - [Self-host on Kubernetes](/deploy/kubernetes)
 - [Use the early access of Restate Cloud](/deploy/cloud)
+- [Running locally](/develop/local_dev)
 
 The server will store metadata and RocksDB data under `./restate-data/<NODE-NAME>`.
 `<NODE-NAME>` is the name of the Restate server, which is set by the `--node-name` flag (defaults to hostname).

--- a/docs/develop/local_dev.mdx
+++ b/docs/develop/local_dev.mdx
@@ -91,46 +91,98 @@ Install the Restate Server and CLI by downloading the binaries with `curl` from 
 
 ## Running Restate locally
 
+<CH.Spotlight className={"spotlight-medium"}>
+    Start the Restate Server:
 
+    ```shell
+    restate-server
+    ```
+</CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
+    Start the Restate Server and wipe ongoing invocations and K/V state.
 
-<CH.Spotlight>
+    ```shell
+    restate-server --wipe all
+    ```
+</CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
+    Check out all available commands and configuration options ([docs](/operate/configuration/server)):
+
+    ```shell
+    restate-server --help
+    ```
+</CH.Spotlight>
+
+## Useful dev CLI commands
+
+<CH.Spotlight className={"spotlight-medium"}>
     Check if the CLI is installed correctly and can find the server:
 
     ```shell
     restate whoami
     ```
 </CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
+    Register a new service deployment:
 
---wipe
+    ```shell
+    restate deployments register localhost:9080
+    ```
+</CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
 
---config
+    [Cancel](/operate/invocation#cancelling-invocations) a single invocation or a batch of invocations.
+    Use `--kill` to [kill](/operate/invocation#killing-invocations) the invocation.
+    To remove all invocations, restart the server with `--wipe all`.
 
-## Useful dev CLI commands
+    ```shell
+    restate invocation cancel <INVOCATION_ID>
+    # also works with <SERVICE>/<SERVICE_KEY>/<HANDLER> or a subset of it
+    ```
 
-```shell
-restate invocation cancel
-```
+</CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
 
-```shell
-restate invocation prune
-```
+    Purge completed invocations from the state:
 
-```shell
-restate kv clear
-```
+    ```shell
+    restate invocation purge <INVOCATION_ID>
+    # also works with <SERVICE>/<SERVICE_KEY>/<HANDLER> or a subset of it
+    ```
 
-```shell
-restate sql --json "query"
-```
+</CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
+
+    Clear the K/V state of a Virtual Object or Workflows.
+    To clear all state, restart the server with `--wipe all`.
+
+    ```shell
+    restate kv clear <OBJECT_OR_WORKFLOW_NAME>
+    restate kv clear <OBJECT_OR_WORKFLOW_NAME>/<SERVICE_KEY>
+    ```
+
+</CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
+
+    Execute a SQL query on the invocation or application state.
+    See [SQL introspection docs](/operate/introspection?interface=psql#inspecting-invocations) for example queries.
+
+    ```shell
+    restate sql --json "query"
+    ```
+
+</CH.Spotlight>
+<CH.Spotlight className={"spotlight-medium"}>
+
+    Check out all available commands:
+
+    ```shell
+    restate --help
+    ```
+
+</CH.Spotlight>
 
 
-Print help to see all available commands:
-
-```shell
-restate --help
-```
-
-<Admonition type="tip">
-    The CLI can be a useful tool for debugging and troubleshooting.
-    Have a look at the [introspection page](/operate/introspection) for a list of useful commands .
+<Admonition type="tip" title={"Debugging and troubleshooting with the CLI"}>
+    Have a look at the [introspection page](/operate/introspection) for a list of useful commands.
 </Admonition>

--- a/docs/develop/local_dev.mdx
+++ b/docs/develop/local_dev.mdx
@@ -54,38 +54,42 @@ import Tabs from "@theme/Tabs";
     <TabItem value={"bin"} label={"Download binaries"}>
         Install the Restate Server and CLI by downloading the binaries with `curl` from the [releases page](https://github.com/restatedev/restate/releases/latest), and make them executable:
 
-        <CH.Code rows={"5"}>
+        <CH.Code>
 
             ```shell MacOS-x64
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-apple-darwin.tar.gz && \
-            tar -xvf restate.x86_64-apple-darwin.tar.gz && \
+            BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
+            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
             chmod +x restate restate-server && \
-            sudo mv restate /usr/local/bin/ && \
-            sudo mv restate-server /usr/local/bin/
+            mv restate $BIN && \
+            mv restate-server $BIN
             ```
 
             ```shell MacOS-arm64
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-apple-darwin.tar.gz && \
-            tar -xvf restate.aarch64-apple-darwin.tar.gz && \
+            BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
+            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
             chmod +x restate restate-server && \
-            sudo mv restate /usr/local/bin/ && \
-            sudo mv restate-server /usr/local/bin/
+            mv restate $BIN && \
+            mv restate-server $BIN
             ```
 
             ```shell Linux-x64
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-unknown-linux-musl.tar.gz && \
-            tar -xvf restate.x86_64-unknown-linux-musl.tar.gz && \
+            BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
+            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
             chmod +x restate restate-server && \
-            sudo mv restate /usr/local/bin/ && \
-            sudo mv restate-server /usr/local/bin/
+            mv restate $BIN && \
+            mv restate-server $BIN
             ```
 
             ```shell Linux-arm64
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-unknown-linux-musl.tar.gz && \
-            tar -xvf restate.aarch64-unknown-linux-musl.tar.gz && \
+            BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
+            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
             chmod +x restate restate-server && \
-            sudo mv restate /usr/local/bin/ && \
-            sudo mv restate-server /usr/local/bin/
+            mv restate $BIN && \
+            mv restate-server $BIN
             ```
         </CH.Code>
 

--- a/docs/develop/local_dev.mdx
+++ b/docs/develop/local_dev.mdx
@@ -4,114 +4,121 @@ description: "Learn how to set up your local dev environment"
 ---
 
 import Admonition from '@theme/Admonition';
+import TabItem from "@theme/TabItem";
+import Tabs from "@theme/Tabs";
 
 # Local Dev
 
-## Install Restate Server & CLI
-### Option 1: Using a package manager
+## Running Restate Server & CLI locally
+<Tabs groupId={"running-restate"}>
+    <TabItem value={"npm"} label={"npm"}>
+        <CH.Spotlight className={"spotlight-medium"}>
+            Install Restate Server and run it:
+            ```shell
+            npm install --global @restatedev/restate-server@latest &&
+            restate-server
+            ```
+        </CH.Spotlight>
+        <CH.Spotlight className={"spotlight-medium"}>
+            Or use npx, without installation:
+            ```shell
+            npx @restatedev/restate-server
+            ```
+        </CH.Spotlight>
+        <CH.Spotlight className={"spotlight-medium"}>
+            Install the Restate CLI via:
+            ```shell
+            npm install --global @restatedev/restate@latest
+            ```
+        </CH.Spotlight>
 
-<CH.Spotlight>
-Install the Restate Server via:
+    </TabItem>
+    <TabItem value={"Homebrew"}  label={"Homebrew"}>
+        <CH.Spotlight className={"spotlight-medium"}>
 
-<CH.Code rows={2}>
-    ```shell npm
-    npm install --global @restatedev/restate-server@latest
-    ```
-
-    ``` shell Homebrew
-    brew install restatedev/tap/restate-server && restate-server
-    ```
-
-    ```shell Docker
-    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
-    ```
-</CH.Code>
-</CH.Spotlight>
-
-
-<CH.Spotlight>
-    Install the Restate CLI via:
-
-    <CH.Code>
-
-        ```shell npm
-        npm install --global @restatedev/restate@latest
+        Install Restate Server and run it with:
+        ```shell
+        brew install restatedev/tap/restate-server &&
+        restate-server
         ```
+        </CH.Spotlight>
 
-        ```shell Homebrew
+        <CH.Spotlight className={"spotlight-medium"}>
+        Install the CLI via:
+        ```shell
         brew install restatedev/tap/restate
         ```
+        </CH.Spotlight>
 
-    </CH.Code>
-</CH.Spotlight>
-### Option 2: Download the binary
+    </TabItem>
+    <TabItem value={"bin"} label={"Download binaries"}>
+        Install the Restate Server and CLI by downloading the binaries with `curl` from the [releases page](https://github.com/restatedev/restate/releases/latest), and make them executable:
 
-Install the Restate Server and CLI by downloading the binaries with `curl` from the [releases page](https://github.com/restatedev/restate/releases/latest), and make them executable:
+        <CH.Code rows={"5"}>
 
-<CH.Code rows={"5"}>
+            ```shell MacOS-x64
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-apple-darwin.tar.gz && \
+            tar -xvf restate.x86_64-apple-darwin.tar.gz && \
+            chmod +x restate restate-server && \
+            sudo mv restate /usr/local/bin/ && \
+            sudo mv restate-server /usr/local/bin/
+            ```
 
-    ```shell MacOS-x64
-    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-apple-darwin.tar.gz && \
-    tar -xvf restate.x86_64-apple-darwin.tar.gz && \
-    chmod +x restate restate-server && \
-    sudo mv restate /usr/local/bin/ && \
-    sudo mv restate-server /usr/local/bin/
-    ```
+            ```shell MacOS-arm64
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-apple-darwin.tar.gz && \
+            tar -xvf restate.aarch64-apple-darwin.tar.gz && \
+            chmod +x restate restate-server && \
+            sudo mv restate /usr/local/bin/ && \
+            sudo mv restate-server /usr/local/bin/
+            ```
 
-    ```shell MacOS-arm64
-    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-apple-darwin.tar.gz && \
-    tar -xvf restate.aarch64-apple-darwin.tar.gz && \
-    chmod +x restate restate-server && \
-    sudo mv restate /usr/local/bin/ && \
-    sudo mv restate-server /usr/local/bin/
-    ```
+            ```shell Linux-x64
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-unknown-linux-musl.tar.gz && \
+            tar -xvf restate.x86_64-unknown-linux-musl.tar.gz && \
+            chmod +x restate restate-server && \
+            sudo mv restate /usr/local/bin/ && \
+            sudo mv restate-server /usr/local/bin/
+            ```
 
-    ```shell Linux-x64
-    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-unknown-linux-musl.tar.gz && \
-    tar -xvf restate.x86_64-unknown-linux-musl.tar.gz && \
-    chmod +x restate restate-server && \
-    sudo mv restate /usr/local/bin/ && \
-    sudo mv restate-server /usr/local/bin/
-    ```
+            ```shell Linux-arm64
+            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-unknown-linux-musl.tar.gz && \
+            tar -xvf restate.aarch64-unknown-linux-musl.tar.gz && \
+            chmod +x restate restate-server && \
+            sudo mv restate /usr/local/bin/ && \
+            sudo mv restate-server /usr/local/bin/
+            ```
+        </CH.Code>
 
-    ```shell Linux-arm64
-    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-unknown-linux-musl.tar.gz && \
-    tar -xvf restate.aarch64-unknown-linux-musl.tar.gz && \
-    chmod +x restate restate-server && \
-    sudo mv restate /usr/local/bin/ && \
-    sudo mv restate-server /usr/local/bin/
-    ```
-</CH.Code>
+        Then run it with:
+        ```shell
+        restate-server
+        ```
+
+    </TabItem>
+    <TabItem value={"Docker"} label={"Docker"}>
+        ```shell
+        docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
+        --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+        ```
+    </TabItem>
+</Tabs>
+
 
 <Admonition type="note" title="Server and CLI configuration">
     Have a look at the [CLI configuration docs](/operate/configuration/cli) or [Server configuration docs](/operate/configuration/server) for more configuration options.
 </Admonition>
 
 
-## Running Restate locally
+<details>
+    <summary> Wiping Restate </summary>
 
-<CH.Spotlight className={"spotlight-medium"}>
-    Start the Restate Server:
-
-    ```shell
-    restate-server
-    ```
-</CH.Spotlight>
-<CH.Spotlight className={"spotlight-medium"}>
     Start the Restate Server and wipe ongoing invocations and K/V state.
 
     ```shell
     restate-server --wipe all
     ```
-</CH.Spotlight>
-<CH.Spotlight className={"spotlight-medium"}>
-    Check out all available commands and configuration options ([docs](/operate/configuration/server)):
 
-    ```shell
-    restate-server --help
-    ```
-</CH.Spotlight>
+</details>
 
 ## Useful dev CLI commands
 
@@ -123,7 +130,8 @@ Install the Restate Server and CLI by downloading the binaries with `curl` from 
     ```
 </CH.Spotlight>
 <CH.Spotlight className={"spotlight-medium"}>
-    Register a new service deployment:
+    Register a new service deployment. <br/>
+    When running Restate in a Docker, replace localhost with host.docker.internal.
 
     ```shell
     restate deployments register localhost:9080
@@ -166,18 +174,10 @@ Install the Restate Server and CLI by downloading the binaries with `curl` from 
 
     Execute a SQL query on the invocation or application state.
     See [SQL introspection docs](/operate/introspection?interface=psql#inspecting-invocations) for example queries.
+    Use `--json` to get the output in json format.
 
     ```shell
-    restate sql --json "query"
-    ```
-
-</CH.Spotlight>
-<CH.Spotlight className={"spotlight-medium"}>
-
-    Check out all available commands:
-
-    ```shell
-    restate --help
+    restate sql "query"
     ```
 
 </CH.Spotlight>

--- a/docs/develop/local_dev.mdx
+++ b/docs/develop/local_dev.mdx
@@ -1,0 +1,136 @@
+---
+sidebar_position: 2
+description: "Learn how to set up your local dev environment"
+---
+
+import Admonition from '@theme/Admonition';
+
+# Local Dev
+
+## Install Restate Server & CLI
+### Option 1: Using a package manager
+
+<CH.Spotlight>
+Install the Restate Server via:
+
+<CH.Code rows={2}>
+    ```shell npm
+    npm install --global @restatedev/restate-server@latest
+    ```
+
+    ``` shell Homebrew
+    brew install restatedev/tap/restate-server && restate-server
+    ```
+
+    ```shell Docker
+    docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
+    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+    ```
+</CH.Code>
+</CH.Spotlight>
+
+
+<CH.Spotlight>
+    Install the Restate CLI via:
+
+    <CH.Code>
+
+        ```shell npm
+        npm install --global @restatedev/restate@latest
+        ```
+
+        ```shell Homebrew
+        brew install restatedev/tap/restate
+        ```
+
+    </CH.Code>
+</CH.Spotlight>
+### Option 2: Download the binary
+
+Install the Restate Server and CLI by downloading the binaries with `curl` from the [releases page](https://github.com/restatedev/restate/releases/latest), and make them executable:
+
+<CH.Code rows={"5"}>
+
+    ```shell MacOS-x64
+    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-apple-darwin.tar.gz && \
+    tar -xvf restate.x86_64-apple-darwin.tar.gz && \
+    chmod +x restate restate-server && \
+    sudo mv restate /usr/local/bin/ && \
+    sudo mv restate-server /usr/local/bin/
+    ```
+
+    ```shell MacOS-arm64
+    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-apple-darwin.tar.gz && \
+    tar -xvf restate.aarch64-apple-darwin.tar.gz && \
+    chmod +x restate restate-server && \
+    sudo mv restate /usr/local/bin/ && \
+    sudo mv restate-server /usr/local/bin/
+    ```
+
+    ```shell Linux-x64
+    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-unknown-linux-musl.tar.gz && \
+    tar -xvf restate.x86_64-unknown-linux-musl.tar.gz && \
+    chmod +x restate restate-server && \
+    sudo mv restate /usr/local/bin/ && \
+    sudo mv restate-server /usr/local/bin/
+    ```
+
+    ```shell Linux-arm64
+    curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-unknown-linux-musl.tar.gz && \
+    tar -xvf restate.aarch64-unknown-linux-musl.tar.gz && \
+    chmod +x restate restate-server && \
+    sudo mv restate /usr/local/bin/ && \
+    sudo mv restate-server /usr/local/bin/
+    ```
+</CH.Code>
+
+<Admonition type="note" title="Server and CLI configuration">
+    Have a look at the [CLI configuration docs](/operate/configuration/cli) or [Server configuration docs](/operate/configuration/server) for more configuration options.
+</Admonition>
+
+
+## Running Restate locally
+
+
+
+<CH.Spotlight>
+    Check if the CLI is installed correctly and can find the server:
+
+    ```shell
+    restate whoami
+    ```
+</CH.Spotlight>
+
+--wipe
+
+--config
+
+## Useful dev CLI commands
+
+```shell
+restate invocation cancel
+```
+
+```shell
+restate invocation prune
+```
+
+```shell
+restate kv clear
+```
+
+```shell
+restate sql --json "query"
+```
+
+
+Print help to see all available commands:
+
+```shell
+restate --help
+```
+
+<Admonition type="tip">
+    The CLI can be a useful tool for debugging and troubleshooting.
+    Have a look at the [introspection page](/operate/introspection) for a list of useful commands .
+</Admonition>

--- a/docs/develop/local_dev.mdx
+++ b/docs/develop/local_dev.mdx
@@ -112,7 +112,7 @@ import Tabs from "@theme/Tabs";
 <details>
     <summary> Wiping Restate </summary>
 
-    Start the Restate Server and wipe ongoing invocations and K/V state.
+    To start the Restate Server from a clean slate and wipe ongoing invocations and K/V state:
 
     ```shell
     restate-server --wipe all

--- a/docs/get_started/quickstart.mdx
+++ b/docs/get_started/quickstart.mdx
@@ -87,7 +87,25 @@ curl localhost:9070/deployments -H 'content-type: application/json' \
 
 If you run Restate with Docker, use `http://host.docker.internal:9080` instead of `http://localhost:9080`.
 
-You should see the registered services and handlers printed to your terminal.
+<details className={"grey-details"}>
+
+    <summary>Output</summary>
+
+    ```shell
+    ❯ SERVICES THAT WILL BE ADDED:
+    - Greeter
+    Type: Service
+    HANDLER  INPUT                                     OUTPUT
+    greet    value of content-type 'application/json'  value of content-type 'application/json'
+
+
+    ✔ Are you sure you want to apply those changes? · yes
+    ✅ DEPLOYMENT:
+    SERVICE  REV
+    Greeter  1
+    ```
+
+</details>
 
 </Step>
 
@@ -201,6 +219,26 @@ Tell Restate where the service is running, so Restate can discover and register 
 </CH.Code>
 
 If you run Restate with Docker, use `http://host.docker.internal:9080` instead of `http://localhost:9080`.
+
+<details className={"grey-details"}>
+
+    <summary>Output</summary>
+
+    ```shell
+    ❯ SERVICES THAT WILL BE ADDED:
+    - Greeter
+    Type: Service
+    HANDLER  INPUT                                     OUTPUT
+    greet    value of content-type 'application/json'  value of content-type 'application/json'
+
+
+    ✔ Are you sure you want to apply those changes? · yes
+    ✅ DEPLOYMENT:
+    SERVICE  REV
+    Greeter  1
+    ```
+
+</details>
 
 </Step>
 
@@ -317,6 +355,26 @@ You should now see printed as response: `Hi!`
     </CH.Code>
 
     If you run Restate with Docker, use `http://host.docker.internal:9080` instead of `http://localhost:9080`.
+
+    <details className={"grey-details"}>
+
+        <summary>Output</summary>
+
+        ```shell
+        ❯ SERVICES THAT WILL BE ADDED:
+        - Greeter
+        Type: Service
+        HANDLER  INPUT                                     OUTPUT
+        greet    value of content-type 'application/json'  value of content-type 'application/json'
+
+
+        ✔ Are you sure you want to apply those changes? · yes
+        ✅ DEPLOYMENT:
+        SERVICE  REV
+        Greeter  1
+        ```
+
+    </details>
 
 </Step>
 

--- a/docs/get_started/quickstart.mdx
+++ b/docs/get_started/quickstart.mdx
@@ -12,53 +12,38 @@ import {Step} from "../../src/components/Stepper";
 # Quickstart
 This guide takes you through your first steps with Restate.
 
-<Admonition type="note" title="Prerequisites">
-- Build tools for your programming language:
-    - TypeScript: Latest stable version of [NodeJS](https://nodejs.org/en/) >= v18.17.1 and [npm CLI](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= 9.6.7
-    - Java/Kotlin: [JDK](https://whichjdk.com/) >= 11
-- Optional but recommended: [Install the Restate CLI](/operate/cli#installation)
-</Admonition>
-
 <Tabs groupId="sdk" queryString>
 <TabItem value="ts" label="TypeScript" default>
 
-<Step stepLabel="1" title="Get the project template">
+<Admonition type="note" title="Prerequisites">
+- TypeScript: Latest stable version of [NodeJS](https://nodejs.org/en/) >= v18.17.1 and [npm CLI](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= 9.6.7
+- Optional but recommended: [Install the Restate CLI](/develop/local_dev#install-restate-server--cli)
+</Admonition>
 
-Use the [Node template](https://github.com/restatedev/node-template-generator) to get started.
-This template includes a skeleton of a TypeScript Restate service:
+<Step stepLabel="1" title="Get the Greeter service template">
 
-```shell
-npx -y @restatedev/create-app@latest && cd restate-node-template
-```
-
-Get all the dependencies and build tools:
+Download the [Node template](https://github.com/restatedev/node-template-generator) with a skeleton of a Restate service. And install its dependencies:
 
 ```shell
+npx -y @restatedev/create-app@latest && cd restate-node-template && \
 npm install
 ```
 
 </Step>
-<Step stepLabel="2" title="Build and run the service">
+<Step stepLabel="2" title="Run the Greeter service">
 
-Now, you are all set to start developing your service in `src/app.ts`.
-You can run the app with `ts-node-dev` while developing:
+Now, start developing your service in `src/app.ts`. Run it with [`ts-node-dev`](https://www.npmjs.com/package/ts-node-dev), and let it listen on port `9080` for requests:
 
 ```shell
 npm run app-dev
 ```
 
-Once you have implemented your service, build the app and run it:
-
-```shell
-npm run build
-npm run app
-```
-
-This starts the greeter service on port `9080`.
-
 </Step>
 
 <Step stepLabel="3" title="Launch Restate">
+Restate is a single self-contained binary. No external dependencies needed. Run it locally via ([or download the binaries](/develop/local_dev#option-2-download-the-binary)):
+
+
 <CH.Code rows={"2"}>
 
 ```shell npx
@@ -76,22 +61,21 @@ docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
 
 </CH.Code>
 
-<Admonition type="tip" icon="💡" title="Single binary">
-Restate is a single self-contained binary. No external dependencies needed. Check out our [download page](https://restate.dev/get-restate/) for other ways to run Restate.
-</Admonition>
-
 </Step>
 
 <Step stepLabel="4" title="Register the service">
 
-Now, we need to tell Restate where the service is running.
-You can use the Restate CLI via `npx` or via a global `npm` install.
-Alternatively, you can use `curl`:
+Tell Restate where the service is running, so Restate can discover and register the services and handlers behind this endpoint:
 
 <CH.Code rows={"2"}>
 
 ```shell CLI
-restate dp add http://localhost:9080
+# link /develop/local_dev#install-restate-server--cli
+restate deployments register http://localhost:9080
+```
+
+```shell npx
+npx @restatedev/restate deployments register http://localhost:9080
 ```
 
 ```shell curl
@@ -101,39 +85,54 @@ curl localhost:9070/deployments -H 'content-type: application/json' \
 
 </CH.Code>
 
-If you run Restate with Docker, you need to use `http://host.docker.internal:9080` instead of `http://localhost:9080` to reach the service deployment.
+If you run Restate with Docker, use `http://host.docker.internal:9080` instead of `http://localhost:9080`.
 
-Restate then sends a request to the service deployment to ask which services and handlers
-are running behind this endpoint and will remember these.
-After executing this curl request, you should see the registered services and handlers printed to your terminal.
+You should see the registered services and handlers printed to your terminal.
 
 </Step>
 
-<Step stepLabel="5" title="Send requests to the service">
-
-Invoke the function via:
+<Step stepLabel="5" title="Send a request to the Greeter service">
 
 ```shell
-curl localhost:8080/Greeter/greet -H 'content-type: application/json' \
-    -d '"Hi"'
+curl localhost:8080/Greeter/greet -H 'content-type: application/json' -d '"Hi"'
 ```
 
 You should now see printed as response: `Hi!`
 
 </Step>
+<Step end={true} stepLabel="🎉" title="Congratulations, you managed to run your first Restate service!"/>
+
+<details className="grey-details">
+
+<summary>Next: Build and run the app</summary>
+
+    Once you have implemented your service, build the app and run it with:
+
+```shell
+npm run build
+npm run app
+```
+
+</details>
 
 </TabItem>
 <TabItem value="java" label="Java" default>
-
-<Step stepLabel="1" title="Get the project template">
-
-Download Java Hello world example:
+<Admonition type="note" title="Prerequisites">
+    - Java: [JDK](https://whichjdk.com/) >= 11
+    - Optional but recommended: [Install the Restate CLI](/develop/local_dev#install-restate-server--cli)
+</Admonition>
+<Step stepLabel="1" title="Get the Greeter service template">
 
 <CH.Code>
-
 ```shell CLI
+# link(1:3) /develop/local_dev#install-restate-server--cli
 restate example java-hello-world-gradle &&
-    cd java-hello-world-gradle
+cd java-hello-world-gradle
+```
+
+```shell npx
+npx @restatedev/restate example java-hello-world-gradle &&
+cd java-hello-world-gradle
 ```
 
 ```shell wget
@@ -145,16 +144,11 @@ wget https://github.com/restatedev/examples/releases/latest/download/java-hello-
 </CH.Code>
 
 </Step>
-<Step stepLabel="2" title="Build and run the service">
+<Step stepLabel="2" title="Run the Greeter service">
 
 You are all set to start developing your service.
-
-```shell
-./gradlew build
-```
-
 Open the project in an IDE and configure it to build with Gradle.
-Run your service via:
+Run your service and let it listen on port `9080` for requests:
 
 ```shell
 ./gradlew run
@@ -163,6 +157,7 @@ Run your service via:
 </Step>
 
 <Step stepLabel="3" title="Launch Restate">
+Restate is a single self-contained binary. No external dependencies needed. Run it locally via ([or download the binaries](/develop/local_dev#option-2-download-the-binary)):
 
 <CH.Code rows={"2"}>
 
@@ -181,22 +176,21 @@ Run your service via:
 
 </CH.Code>
 
-<Admonition type="tip" icon="💡" title="Single binary">
-    Restate is a single self-contained binary. No external dependencies needed. Check out our [download page](https://restate.dev/get-restate/) for other ways to run Restate.
-</Admonition>
-
 </Step>
 
 <Step stepLabel="4" title="Register the service">
 
-Now, we need to tell Restate where the service is running.
-You can use the Restate CLI via `npx` or via a global `npm` install.
-Alternatively, you can use `curl`:
+Tell Restate where the service is running, so Restate can discover and register the services and handlers behind this endpoint:
 
 <CH.Code rows={"2"}>
 
     ```shell CLI
-    restate dp add http://localhost:9080
+    # link /develop/local_dev#install-restate-server--cli
+    restate deployments register http://localhost:9080
+    ```
+
+    ```shell npx
+    npx @restatedev/restate deployments register http://localhost:9080
     ```
 
     ```shell curl
@@ -206,17 +200,11 @@ Alternatively, you can use `curl`:
 
 </CH.Code>
 
-If you run Restate with Docker, you need to use `http://host.docker.internal:9080` instead of `http://localhost:9080` to reach the service deployment.
-
-Restate then sends a request to the service deployment to ask which services and handlers
-are running behind this endpoint and will remember these.
-After executing this curl request, you should see the registered services and handlers printed to your terminal.
+If you run Restate with Docker, use `http://host.docker.internal:9080` instead of `http://localhost:9080`.
 
 </Step>
 
-<Step stepLabel="5" title="Send requests to the service">
-
-Invoke the function via:
+<Step stepLabel="5" title="Send a request to the Greeter service">
 
 ```shell
 curl localhost:8080/Greeter/greet -H 'content-type: application/json' -d '"Hi!"'
@@ -225,19 +213,40 @@ curl localhost:8080/Greeter/greet -H 'content-type: application/json' -d '"Hi!"'
 You should now see printed as response: `Hi!`
 
 </Step>
-</TabItem>
+<Step end={true} stepLabel="🎉" title="Congratulations, you managed to run your first Restate service!"/>
 
+<details className="grey-details">
+    <summary>Next: Build the app</summary>
+
+    Once you have implemented your service, build the app with:
+
+    ```shell
+    ./gradlew build
+    ```
+
+</details>
+
+</TabItem>
 <TabItem value="kotlin" label="Kotlin" default>
 
-<Step stepLabel="1" title="Get the project template">
+<Admonition type="note" title="Prerequisites">
+    - Java/Kotlin: [JDK](https://whichjdk.com/) >= 11
+    - Optional but recommended: [Install the Restate CLI](/develop/local_dev#install-restate-server--cli)
+</Admonition>
 
-    Download Kotlin Hello world example:
+<Step stepLabel="1" title="Get the Greeter service template">
 
     <CH.Code>
 
         ```shell CLI
+        # link(1:2) /develop/local_dev#install-restate-server--cli
         restate example kotlin-hello-world-gradle &&
-            cd kotlin-hello-world-gradle
+        cd kotlin-hello-world-gradle
+        ```
+
+        ```shell npx
+        npx @restatedev/restate example kotlin-hello-world-gradle &&
+        cd kotlin-hello-world-gradle
         ```
 
         ```shell wget
@@ -249,16 +258,11 @@ You should now see printed as response: `Hi!`
     </CH.Code>
 
 </Step>
-<Step stepLabel="2" title="Build and run the service">
+<Step stepLabel="2" title="Run the Greeter service">
 
     You are all set to start developing your service.
-
-    ```shell
-    ./gradlew build
-    ```
-
     Open the project in an IDE and configure it to build with Gradle.
-    Run your service via:
+    Run your service and let it listen on port `9080` for requests:
 
     ```shell
     ./gradlew run
@@ -267,6 +271,8 @@ You should now see printed as response: `Hi!`
 </Step>
 
 <Step stepLabel="3" title="Launch Restate">
+
+    Restate is a single self-contained binary. No external dependencies needed. Run it locally via ([or download the binaries](/develop/local_dev#option-2-download-the-binary)):
 
     <CH.Code rows={"2"}>
 
@@ -285,42 +291,36 @@ You should now see printed as response: `Hi!`
 
     </CH.Code>
 
-    <Admonition type="tip" icon="💡" title="Single binary">
-        Restate is a single self-contained binary. No external dependencies needed. Check out our [download page](https://restate.dev/get-restate/) for other ways to run Restate.
-    </Admonition>
 
 </Step>
 
 <Step stepLabel="4" title="Register the service">
 
-    Now, we need to tell Restate where the service is running.
-    You can use the Restate CLI via `npx` or via a global `npm` install.
-    Alternatively, you can use `curl`:
+    Tell Restate where the service is running, so Restate can discover and register the services and handlers behind this endpoint:
 
     <CH.Code rows={"2"}>
 
         ```shell CLI
-        restate dp add http://localhost:9080
+        # link /develop/local_dev#install-restate-server--cli
+        restate deployments register http://localhost:9080
+        ```
+
+        ```shell npx
+        npx @restatedev/restate deployments register http://localhost:9080
         ```
 
         ```shell curl
         curl localhost:9070/deployments -H 'content-type: application/json' \
-            -d '{"uri": "http://localhost:9080"}'
+        -d '{"uri": "http://localhost:9080"}'
         ```
 
     </CH.Code>
 
-    If run Restate with Docker, you need to use `http://host.docker.internal:9080` instead of `http://localhost:9080` to reach the service deployment.
-
-    Restate then sends a request to the service deployment to ask which services and handlers
-    are running behind this endpoint and will remember these.
-    After executing this curl request, you should see the registered services and handlers printed to your terminal.
+    If you run Restate with Docker, use `http://host.docker.internal:9080` instead of `http://localhost:9080`.
 
 </Step>
 
-<Step stepLabel="5" title="Send requests to the service">
-
-    Invoke the function via:
+<Step stepLabel="5" title="Send a request to the Greeter service">
 
     ```shell
     curl localhost:8080/Greeter/greet -H 'content-type: application/json' -d '"Hi"'
@@ -329,12 +329,26 @@ You should now see printed as response: `Hi!`
     You should now see printed as response: `Hi!`
 
 </Step>
+
+<Step end={true} stepLabel="🎉" title="Congratulations, you managed to run your first Restate service!"/>
+
+<details className="grey-details">
+
+    <summary>Next: Build the app</summary>
+
+    Once you have implemented your service, build the app with:
+
+    ```shell
+    ./gradlew build
+    ```
+
+</details>
+
 </TabItem>
 </Tabs>
-Congratulations, you managed to run your first Restate service!
+
 
 ## Next steps
-
-Possible next steps:
+- Read the [Concepts](/concepts/durable_building_blocks)
 - Discover the key features of Restate in the [Tour of Restate](/get_started/tour)
 - [Run the examples](https://github.com/restatedev/examples)

--- a/docs/get_started/tour.mdx
+++ b/docs/get_started/tour.mdx
@@ -41,7 +41,7 @@ As we go, you will discover how Restate can help you with some intricacies in th
 <TabItem value="ts" label="TypeScript">
 
 - Latest stable version of [NodeJS](https://nodejs.org/en/) >= v18.17.1 and [npm CLI](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) >= 9.6.7 installed.
-- Restate CLI: [Installation instructions](/operate/cli#installation)
+- Restate CLI: [Installation instructions](/develop/local_dev#install-restate-server--cli)
 - Optional: [Docker Engine](https://docs.docker.com/engine/install/) or [Podman](https://podman.io/docs/installation), if you want to run the Restate Server with Docker. And to run Jaeger.
 
 This guide is written for:
@@ -51,7 +51,7 @@ This guide is written for:
 </TabItem>
 <TabItem value="java" label="Java">
 - JDK >= 11
-- Restate CLI: [Installation instructions](/operate/cli#installation)
+- Restate CLI: [Installation instructions](/develop/local_dev#install-restate-server--cli)
 - Optional: [Docker Engine](https://docs.docker.com/engine/install/) or [Podman](https://podman.io/docs/installation), if you want to run the Restate Server with Docker. And to run Jaeger.
 
 This guide is written for:
@@ -672,7 +672,7 @@ Call `CartObject/addTicket` again and have a look at the service logs.
 You see the retries taking place. And you see that only the first time the call to the `CheckoutService` was made.
 The other times, the call was skipped and the journaled response was replayed.
 
-[By default](/operate/configuration#default-configuration), Restate will keep retrying failed invocations until they succeed.
+[By default](/operate/configuration/server#default-configurations), Restate will keep retrying failed invocations until they succeed.
 If you want to cancel an invocation in a retry loop, you can use the CLI to do this. Let's have a look at that next.
 
 ## Debugging with the CLI

--- a/docs/invoke/kafka.mdx
+++ b/docs/invoke/kafka.mdx
@@ -33,7 +33,7 @@ You can invoke handlers via Kafka events, by doing the following:
 </SubtleStep>
 
 <SubtleStep stepLabel="2" title="Configure Restate to connect to a Kafka cluster">
-    Define the Kafka cluster that Restate needs to connect to in the [Restate configuration file](/operate/configuration#configuration-file):
+    Define the Kafka cluster that Restate needs to connect to in the [Restate configuration file](/operate/configuration/server#configuration-file):
 
     ```toml restate.toml
     [[ingress.kafka-clusters]]
@@ -43,7 +43,7 @@ You can invoke handlers via Kafka events, by doing the following:
 
     And make sure the Restate Server uses it via _`restate-server --config-file restate.toml`_.
 
-    Check the [configuration docs](/operate/configuration) for more details.
+    Check the [configuration docs](/operate/configuration/server) for more details.
 </SubtleStep>
 <SubtleStep stepLabel="3" title={<span><a href={"/operate/registration"}>Register the service</a> you want to invoke.</span>}/>
 

--- a/docs/operate/configuration/_category_.json
+++ b/docs/operate/configuration/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Configuration",
+  "position": 3,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/operate/configuration/cli.mdx
+++ b/docs/operate/configuration/cli.mdx
@@ -1,90 +1,26 @@
 ---
-sidebar_position: 1
-description: "Use the CLI to interact with Restate."
+sidebar_position: 2
+description: "Restate CLI configuration options."
 ---
 
 import Admonition from '@theme/Admonition';
 
-# CLI
+# Restate CLI
 
 You can use the CLI to interact with Restate, and manage your services, deployments and invocations.
 
-## Installation
-
-### Option 1: Using a package manager
-
-Install the Restate CLI via:
-
-<CH.Code>
-
-```shell npm
-npm install --global @restatedev/restate
-```
-
-```shell Homebrew
-brew install restatedev/tap/restate
-```
-
-</CH.Code>
-
-### Option 2: Download the binary
-
-Use `curl` to download the binaries from the [releases page](https://github.com/restatedev/restate/releases/latest), and make them executable:
-
-<CH.Code rows={"5"}>
-
-```shell MacOS-x64
-curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-apple-darwin.tar.gz && \
-tar -xvf restate.x86_64-apple-darwin.tar.gz && \
-chmod +x restate && \
-sudo mv restate /usr/local/bin/
-```
-
-```shell MacOS-arm64
-curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-apple-darwin.tar.gz && \
-tar -xvf restate.aarch64-apple-darwin.tar.gz && \
-chmod +x restate && \
-sudo mv restate /usr/local/bin/
-```
-
-```shell Linux-x64
-curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.x86_64-unknown-linux-musl.tar.gz && \
-tar -xvf restate.x86_64-unknown-linux-musl.tar.gz && \
-chmod +x restate && \
-sudo mv restate /usr/local/bin/
-```
-
-```shell Linux-arm64
-curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.aarch64-unknown-linux-musl.tar.gz && \
-tar -xvf restate.aarch64-unknown-linux-musl.tar.gz && \
-chmod +x restate && \
-sudo mv restate /usr/local/bin/
-```
-
-</CH.Code>
-
-Check if the CLI is configured correctly:
-
-```shell
-restate whoami
-```
-
-Print help to see all available commands:
-
-```shell
-restate --help
-```
+<Admonition type="note" title="Installing the CLI">
+    Have a look at the [CLI installation docs](/develop/local_dev#install-restate-server--cli).
+</Admonition>
 
 <Admonition type="tip">
     The CLI can be a useful tool for debugging and troubleshooting.
     Have a look at the [introspection page](/operate/introspection) for a list of useful commands .
 </Admonition>
 
-## Configuration
-
 There are 2 ways to configure the CLI: via environment variables or via a configuration file.
 
-### Using environment variables
+## Using environment variables
 
 You can specify the following environment variables:
 
@@ -111,7 +47,7 @@ For example, to connect to a Restate admin server running at `http://myhost:9070
 RESTATE_ADMIN_URL=http://myhost:9070
 ```
 
-### Using the config file
+## Using the config file
 
 By default, the CLI will treat `$HOME/.config/restate` as its config directory.
 This is configurable with `$RESTATE_CLI_CONFIG_HOME`. Restate will look for file

--- a/docs/operate/configuration/server.mdx
+++ b/docs/operate/configuration/server.mdx
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 3
-description: "Consult the configuration options for Restate."
+sidebar_position: 1
+description: "Consult the configuration options for Restate Server."
 ---
 
 import Schema from "@site/static/schemas/config_schema.json";
@@ -10,13 +10,13 @@ import CodeBlock from '@theme/CodeBlock'
 import Admonition from '@theme/Admonition';
 import DefaultConfig from '!!raw-loader!/static/schemas/restate.toml';
 
-# Configuration
+# Restate Server
 
-Restate has a wide range of configuration options to tune it according to your needs.
+The Restate Server has a wide range of configuration options to tune it according to your needs.
 
 ## Configuration file
 
-Restate accepts a [TOML](https://toml.io/en/) configuration file that can be specified either providing the command-line option `--config-file=<PATH>` or setting the environment variable `RESTATE_CONFIG=<PATH>`. If not set, the [default configuration](#default-configuration) will be applied.
+The Restate Server accepts a [TOML](https://toml.io/en/) configuration file that can be specified either providing the command-line option `--config-file=<PATH>` or setting the environment variable `RESTATE_CONFIG=<PATH>`. If not set, the [default configuration](#default-configuration) will be applied.
 
 ## Overrides
 

--- a/docs/operate/introspection.mdx
+++ b/docs/operate/introspection.mdx
@@ -21,7 +21,7 @@ This can be useful for troubleshooting. For example, a handler might be blocked 
 <TabItem value="cli" label="CLI">
 
 The CLI is the easiest way to get started with introspection.  
-Have a look at the [installation guide](/operate/cli) for the CLI.
+Have a look at the [installation guide](/develop/local_dev#install-restate-server--cli) for the CLI.
 
 </TabItem>
 <TabItem value="psql" label="psql">

--- a/docs/operate/introspection.mdx
+++ b/docs/operate/introspection.mdx
@@ -66,6 +66,8 @@ The Restate Introspection SQL API has been implemented based on [DataFusion](htt
 </TabItem>
 </Tabs>
 
+## Inspecting invocations
+
 ### Listing ongoing invocations
 
 <Tabs groupId="interface" queryString>

--- a/docs/operate/monitoring/logging.md
+++ b/docs/operate/monitoring/logging.md
@@ -7,7 +7,7 @@ description: "Find out how to configure logging for Restate."
 
 By default, Restate logs INFO, WARN and ERROR events using a pretty format.
 
-A complete list of configuration options is available in the [configuration documentation](/operate/configuration).
+A complete list of configuration options is available in the [configuration documentation](/operate/configuration/server).
 
 For service logging, check the [Typescript SDK logging](/develop/ts/logging) and [Java SDK logging](/develop/java/logging) pages.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -130,7 +130,7 @@ description: (
 <i>Observe and upgrade your handlers.</i>
 </p>
 <div id="overviewButtonDiv"><a className="overviewButton btn btn-primary btn-lg familiarButton text-grey"
-href="/operate/cli"
+href="/operate/configuration/cli"
 role="button">○ CLI</a></div>
 <div id="overviewButtonDiv"><a className="overviewButton btn btn-primary btn-lg familiarButton text-grey"
 href="/operate/versioning"

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -130,14 +130,14 @@ description: (
 <i>Observe and upgrade your handlers.</i>
 </p>
 <div id="overviewButtonDiv"><a className="overviewButton btn btn-primary btn-lg familiarButton text-grey"
-href="/operate/configuration/cli"
-role="button">○ CLI</a></div>
+href="/operate/introspection"
+role="button">○ Inspect</a></div>
 <div id="overviewButtonDiv"><a className="overviewButton btn btn-primary btn-lg familiarButton text-grey"
 href="/operate/versioning"
-role="button">○ Versioning</a></div>
+role="button">○ Version</a></div>
 <div id="overviewButtonDiv"><a className="overviewButton btn btn-primary btn-lg familiarButton text-grey"
 href="/category/monitoring"
-role="button">○ Monitoring</a></div>
+role="button">○ Monitor</a></div>
 </>
 ),
 },

--- a/src/components/Stepper/index.tsx
+++ b/src/components/Stepper/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.css';
 
-function Step({title, stepLabel, children}): JSX.Element {
+function Step({end, title, stepLabel, children}): JSX.Element {
     return (
         <div className="container">
             <div className={clsx('row')}>
@@ -11,13 +11,16 @@ function Step({title, stepLabel, children}): JSX.Element {
                     <h6 className={styles.title}>{title}</h6>
                 </div>
             </div>
-            <div className={clsx('row')}>
-                <div className={clsx('col')}>
-                    <div className={styles.feature}>
-                        <p className={styles.description}>{children}</p>
+            {
+                (end) ? <p className={"padding-bottom--md"}></p> : <div className={clsx('row')}>
+                    <div className={clsx('col')}>
+                        <div className={styles.feature}>
+                            <p className={styles.description}>{children}</p>
+                        </div>
                     </div>
                 </div>
-            </div>
+            }
+
         </div>
     );
 }


### PR DESCRIPTION
-Fixes #386 

- Created a local dev page and moved the CLI installation there. 
- Added the installation of the Restate server options as well 
- Moved the remainder of the previous CLI page to the configuration section
- Made the quickstarts more concise and let them refer to the local dev page