### PR TITLE
add missing "status" field

### DIFF
--- a/docs/get_started/tour.mdx
+++ b/docs/get_started/tour.mdx
@@ -474,7 +474,7 @@ curl localhost:8080/CartObject/Mary/addTicket/send -H 'content-type: application
 <details className="grey-details">
 <summary>Output</summary>
 ```json
-{"invocationId":"inv_1aiqX0vFEFNH1Umgre58JiCLgHfTtztYK5"}
+{"invocationId":"inv_1aiqX0vFEFNH1Umgre58JiCLgHfTtztYK5","status":"Accepted"}
 ```
 </details>
 

--- a/docs/invoke/http.mdx
+++ b/docs/invoke/http.mdx
@@ -75,7 +75,7 @@ curl localhost:8080/MyService/myHandler/send \
     <summary>Output</summary>
 
     ```json
-    {"invocationId":"inv_1aiqX0vFEFNH1Umgre58JiCLgHfTtztYK5"}
+    {"invocationId":"inv_1aiqX0vFEFNH1Umgre58JiCLgHfTtztYK5","status":"Accepted"}
     ```
 </details>
 


### PR DESCRIPTION
I was following the tour at https://docs.restate.dev/get_started/tour 
and notices the the response documentation is missing `status` field
![image](https://github.com/restatedev/documentation/assets/52883485/9f7fc54e-388f-4105-a2ec-327fe0cfe7bc)
![image](https://github.com/restatedev/documentation/assets/52883485/a3e4e583-dec2-4b31-9a09-0cdd7dd58a72)
