### PR TITLE
Minor grammar fix in Workflows overview

### DIFF
--- a/docs/concepts/services.mdx
+++ b/docs/concepts/services.mdx
@@ -186,8 +186,8 @@ Virtual objects expose a set of handlers with access to K/V state stored in Rest
 
 ## Workflows
 
-A workflow is a special type of Virtual Object that can be used to implement a set of steps that needs to be executed durably.
-They have some added capabilities such as signaling, querying, additional invocation options, and a longer retention time in the CLI.
+A workflow is a special type of Virtual Object that can be used to implement a set of steps that need to be executed durably.
+Workflows have additional capabilities such as signaling, querying, additional invocation options, and a longer retention time in the CLI.
 
 <Tabs groupId="sdk" queryString>
     <TabItem value="ts" label="TypeScript">


### PR DESCRIPTION
"needs" should be "need" (since it refers to _steps_, which is plural); the other change is purely subjective but I felt it reads better - feel free to ignore!