### PR TITLE
Remove mention of "Python" in TypeScript overview

### DIFF
--- a/docs/develop/ts/overview.mdx
+++ b/docs/develop/ts/overview.mdx
@@ -13,7 +13,7 @@ The Restate TypeScript SDK is open source and can be found on GitHub: ([sdk-type
 Have a look at the [TypeScript Quickstart](/get_started/quickstart?sdk=ts)!
 </Admonition>
 
-Add the `@restatedev/restate-sdk` dependency to your Python project to start developing Restate services.
+Add the `@restatedev/restate-sdk` dependency to your project to start developing Restate services.
 
 The Restate SDK lets you implement handlers.
 Handlers can either be part of a [Service](/concepts/services#services-1), a [Virtual Object](/concepts/services#virtual-objects), or a [Workflow](/concepts/services#workflows). Let's have a look at how to define them.


### PR DESCRIPTION
I just noticed that the TypeScript Overview says

> Add the @restatedev/restate-sdk dependency to your __Python__ project to start developing Restate services.

which is probably a typo?

The Go Overview just says "project" without the language name, so here's a fix that just removes "Python".