### PR TITLE
Use scarf links for all the things (for 1.2.0 only!)

### DIFF
--- a/docs/deploy/deploy.mdx
+++ b/docs/deploy/deploy.mdx
@@ -20,7 +20,7 @@ This page describes how to deploy Restate and Restate services.
 The Restate Server is a single binary that contains everything you need to host an environment. See the [Installation page](/develop/local_dev) for various ways of obtaining it.
 
 There are a few options for deploying the Restate Server:
-- [Cluster deployment](/deploy/server/cluster)
+- [Cluster deployment](/deploy/server/cluster/deployment)
 - [Self-host a single-node Restate server on AWS](/deploy/faas/lambda/self-hosted)
 - [Self-host a single-pod Restate server on Kubernetes](/deploy/kubernetes)
 - [Use Restate Cloud](/deploy/cloud)

--- a/docs/deploy/server/cluster/cluster.mdx
+++ b/docs/deploy/server/cluster/cluster.mdx
@@ -95,13 +95,107 @@ This tool is specifically designed for system operators to manage Restate server
 It is distinct from the application developer-focused `restate` CLI tool, which is used to manage service deployments and invocations.
 
 ### Getting `restatectl`
-You can install `restatectl` using your preferred [installation method](/develop/local_dev).
-The tool is also included in the `restate-cli` and `restate` Docker images.
-To use `restatectl` in a running Docker container, you can use the following command from the host machine to connect to it without spawning a separate container:
 
-```shell
-docker exec <CONTAINER_NAME> restatectl [ARGUMENTS]
-```
+<Tabs groupId={"getting-restatectl"}>
+    <TabItem value={"Homebrew"} label={"Homebrew"}>
+        <TextAndCode>
+            Install with:
+            ```shell !result
+            brew install restatedev/tap/restatectl
+            ```
+        </TextAndCode>
+        <TextAndCode>
+            Then run:
+            ```shell !result
+            restatectl
+            ```
+        </TextAndCode>
+    </TabItem>
+    <TabItem value={"bin"} label={"Download binaries"}>
+        Install restatectl by downloading the binary with `curl` from the [releases page](https://github.com/restatedev/restate/releases/latest), and make them executable:
+
+        <CodeWithTabs>
+
+            ```shell !!tabs Linux-x64
+            BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restatectl-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restatectl-$RESTATE_PLATFORM.tar.xz --strip-components=1 restatectl-$RESTATE_PLATFORM/restatectl && \
+            chmod +x restatectl && \
+
+            # Move the binary to a directory in your PATH, for example ~/.local/bin:
+            mv restatectl $BIN
+            ```
+
+            ```shell !!tabs Linux-arm64
+            BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restatectl-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restatectl-$RESTATE_PLATFORM.tar.xz --strip-components=1 restatectl-$RESTATE_PLATFORM/restatectl && \
+            chmod +x restatectl && \
+
+            # Move the binary to a directory in your PATH, for example ~/.local/bin:
+            mv restatectl $BIN
+            ```
+
+            ```shell !!tabs MacOS-x64
+            BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restatectl-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restatectl-$RESTATE_PLATFORM.tar.xz --strip-components=1 restatectl-$RESTATE_PLATFORM/restatectl && \
+            chmod +x restatectl && \
+
+            # Move the binary to a directory in your PATH, for example /usr/local/bin (needs sudo):
+            sudo mv restatectl $BIN
+            ```
+
+            ```shell !!tabs MacOS-arm64
+            BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restatectl-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restatectl-$RESTATE_PLATFORM.tar.xz --strip-components=1 restatectl-$RESTATE_PLATFORM/restatectl && \
+            chmod +x restatectl && \
+
+            # Move the binary to a directory in your PATH, for example /usr/local/bin (needs sudo):
+            sudo mv restatectl $BIN
+            ```
+
+        </CodeWithTabs>
+
+        Then run:
+        ```shell
+        restatectl
+        ```
+
+    </TabItem>
+    <TabItem value={"npm"} label={"npm"}>
+        <TextAndCode>
+            Install with:
+            ```shell !result
+            npm install --global @restatedev/restatectl@latest
+            ```
+        </TextAndCode>
+        <TextAndCode>
+            Then run:
+            ```shell !result
+            restatectl
+            ```
+        </TextAndCode>
+    </TabItem>
+    <TabItem value={"Docker"} label={"Docker"}>
+
+        The server and CLI images both contain the `restatectl` tool. To run `restatectl`, use the following command:
+
+        ```shell
+        docker run -it --network=host --entrypoint restatectl docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION nodes ls
+        ```
+
+        You can also execute `restatectl` in a running server container using the following command:
+
+        ```shell
+        docker exec restate_dev restatectl nodes ls
+        ```
+
+        Replace `restate_dev` with the name of a running container, and `nodes ls` with the subcommand you want to run.
+
+    </TabItem>
+</Tabs>
 
 ### Using `restatectl`
 The `restatectl` tool communicates with Restate at the advertised address specified in the [server configuration](/operate/configuration/server) - by default TCP port 5122. To get an overview of a running server or cluster, use the `status` command:

--- a/docs/deploy/server/cluster/deployment.mdx
+++ b/docs/deploy/server/cluster/deployment.mdx
@@ -5,6 +5,10 @@ description: "Learn how to deploy a distributed Restate cluster."
 ---
 
 import Admonition from '@theme/Admonition';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import {CodeWithTabs} from "@site/src/components/code/code";
+import {TextAndCode} from "@site/src/components/code/code/text-and-code";
 
 # Restate Cluster Deployment
 

--- a/docs/develop/local_dev.mdx
+++ b/docs/develop/local_dev.mdx
@@ -21,9 +21,7 @@ Restate is a single self-contained binary. No external dependencies needed.
             Install Restate Server and CLI via:
 
             ```shell !result
-            brew install restatedev/tap/restate-server &&
-            brew install restatedev/tap/restatectl &&
-            brew install restatedev/tap/restate
+            brew install restatedev/tap/restate-server restatedev/tap/restate
             ```
         </TextAndCode>
         <TextAndCode>
@@ -40,49 +38,49 @@ Restate is a single self-contained binary. No external dependencies needed.
 
             ```shell !!tabs Linux-x64
             BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
-            chmod +x restate restatectl restate-server && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+            tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
+            chmod +x restate restate-server && \
 
             # Move the binaries to a directory in your PATH, for example ~/.local/bin:
             mv restate $BIN && \
-            mv restatectl $BIN && \
             mv restate-server $BIN
             ```
 
             ```shell !!tabs Linux-arm64
             BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
-            chmod +x restate restatectl restate-server && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+            tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
+            chmod +x restate restate-server && \
 
             # Move the binaries to a directory in your PATH, for example ~/.local/bin:
             mv restate $BIN && \
-            mv restatectl $BIN && \
             mv restate-server $BIN
             ```
 
             ```shell !!tabs MacOS-x64
             BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
-            chmod +x restate restatectl restate-server && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+            tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
+            chmod +x restate restate-server && \
 
             # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
             sudo mv restate $BIN && \
-            sudo mv restatectl $BIN && \
             sudo mv restate-server $BIN
             ```
 
             ```shell !!tabs MacOS-arm64
             BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
-            curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-            tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
-            chmod +x restate restatectl restate-server && \
+            curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+            tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+            tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
+            chmod +x restate restate-server && \
 
             # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
             sudo mv restate $BIN && \
-            sudo mv restatectl $BIN && \
             sudo mv restate-server $BIN
             ```
 
@@ -99,9 +97,7 @@ Restate is a single self-contained binary. No external dependencies needed.
             Install Restate Server and CLI via:
 
             ```shell !result
-            npm install --global @restatedev/restate-server@latest &&
-            npm install --global @restatedev/restatectl@latest &&
-            npm install --global @restatedev/restate@latest
+            npm install --global @restatedev/restate-server@latest @restatedev/restate@latest
             ```
         </TextAndCode>
         <TextAndCode>
@@ -117,13 +113,13 @@ Restate is a single self-contained binary. No external dependencies needed.
 
         ```shell
         docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-        --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+        --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
         ```
 
         To run commands with the Restate CLI, use the following command:
 
         ```shell
-        docker run -it --network=host docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
+        docker run -it --network=host docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
         ```
 
         Replace `invocations ls` with the CLI subcommand you want to run.
@@ -133,7 +129,7 @@ Restate is a single self-contained binary. No external dependencies needed.
         The server and CLI images both contain the `restatectl` tool. To run `restatectl`, use the following command:
 
         ```shell
-        docker run -it --network=host --entrypoint restatectl docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION nodes ls
+        docker run -it --network=host --entrypoint restatectl docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION nodes ls
         ```
 
         You can also execute `restatectl` in a running server container using the following command:

--- a/docs/get_started/quickstart.mdx
+++ b/docs/get_started/quickstart.mdx
@@ -70,8 +70,7 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                         Install Restate Server and CLI.
 
                         ```shell !result
-                        brew install restatedev/tap/restate-server &&
-                        brew install restatedev/tap/restate
+                        brew install restatedev/tap/restate-server restatedev/tap/restate
                         ```
                     </TextAndCode>
                     <TextAndCode>
@@ -87,8 +86,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                     <CodeWithTabs>
                         ```shell !!tabs Linux-x64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -98,8 +98,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-arm64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -109,8 +110,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-x64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -120,8 +122,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-arm64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -142,8 +145,7 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                         Install Restate Server and CLI via:
 
                         ```shell !result
-                        npm install --global @restatedev/restate-server@latest &&
-                        npm install --global @restatedev/restate@latest
+                        npm install --global @restatedev/restate-server@latest @restatedev/restate@latest
                         ```
                     </TextAndCode>
                     <TextAndCode>
@@ -159,13 +161,13 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                     ```shell
                     docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-                    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+                    --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
                     ```
 
                     To run commands with the Restate CLI, use the following command:
 
                     ```shell
-                    docker run -it --network=host docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
+                    docker run -it --network=host docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
                     ```
 
                     Replace `invocations ls` by the CLI command you want to run.
@@ -655,8 +657,7 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                         Install Restate Server and CLI via:
 
                         ```shell !result
-                        brew install restatedev/tap/restate-server &&
-                        brew install restatedev/tap/restate
+                        brew install restatedev/tap/restate-server restatedev/tap/restate
                         ```
                     </TextAndCode>
                     <TextAndCode>
@@ -673,8 +674,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-x64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -684,8 +686,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-arm64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -695,8 +698,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-x64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -706,8 +710,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-arm64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -729,13 +734,13 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                     ```shell
                     docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-                    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+                    --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
                     ```
 
                     To run commands with the Restate CLI, use the following command:
 
                     ```shell
-                    docker run -it --network=host docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
+                    docker run -it --network=host docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
                     ```
 
                     Replace `invocations ls` by the CLI command you want to run.
@@ -1009,8 +1014,7 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                         Install Restate Server and CLI via:
 
                         ```shell !result
-                        brew install restatedev/tap/restate-server &&
-                        brew install restatedev/tap/restate
+                        brew install restatedev/tap/restate-server restatedev/tap/restate
                         ```
                     </TextAndCode>
                     <TextAndCode>
@@ -1027,8 +1031,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-x64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1038,8 +1043,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-arm64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1049,8 +1055,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-x64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1060,8 +1067,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-arm64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1083,13 +1091,13 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                     ```shell
                     docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-                    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+                    --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
                     ```
 
                     To run commands with the Restate CLI, use the following command:
 
                     ```shell
-                    docker run -it --network=host docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
+                    docker run -it --network=host docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
                     ```
 
                     Replace `invocations ls` by the CLI command you want to run.
@@ -1242,8 +1250,7 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                         Install Restate Server and CLI via:
 
                         ```shell !result
-                        brew install restatedev/tap/restate-server &&
-                        brew install restatedev/tap/restate
+                        brew install restatedev/tap/restate-server restatedev/tap/restate
                         ```
                     </TextAndCode>
                     <TextAndCode>
@@ -1260,8 +1267,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-x64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1271,8 +1279,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-arm64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1282,8 +1291,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-x64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1293,8 +1303,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-arm64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1316,13 +1327,13 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                     ```shell
                     docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-                    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+                    --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
                     ```
 
                     To run commands with the Restate CLI, use the following command:
 
                     ```shell
-                    docker run -it --network=host docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
+                    docker run -it --network=host docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
                     ```
 
                     Replace `invocations ls` by the CLI command you want to run.
@@ -1486,8 +1497,7 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                         Install Restate Server and CLI via:
 
                         ```shell !result
-                        brew install restatedev/tap/restate-server &&
-                        brew install restatedev/tap/restate
+                        brew install restatedev/tap/restate-server restatedev/tap/restate
                         ```
                     </TextAndCode>
                     <TextAndCode>
@@ -1504,8 +1514,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-x64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1515,8 +1526,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-arm64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1526,8 +1538,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-x64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1537,8 +1550,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-arm64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1560,13 +1574,13 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                     ```shell
                     docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-                    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+                    --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
                     ```
 
                     To run commands with the Restate CLI, use the following command:
 
                     ```shell
-                    docker run -it --network=host docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
+                    docker run -it --network=host docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
                     ```
 
                     Replace `invocations ls` by the CLI command you want to run.
@@ -1736,8 +1750,7 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
                         Install Restate Server and CLI via:
 
                         ```shell !result
-                        brew install restatedev/tap/restate-server &&
-                        brew install restatedev/tap/restate
+                        brew install restatedev/tap/restate-server restatedev/tap/restate
                         ```
                     </TextAndCode>
                     <TextAndCode>
@@ -1754,8 +1767,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-x64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=x86_64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1765,8 +1779,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs Linux-arm64
                         BIN=$HOME/.local/bin && RESTATE_PLATFORM=aarch64-unknown-linux-musl && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example ~/.local/bin:
@@ -1776,8 +1791,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-x64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=x86_64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1787,8 +1803,9 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                         ```shell !!tabs MacOS-arm64
                         BIN=/usr/local/bin && RESTATE_PLATFORM=aarch64-apple-darwin && \
-                        curl -LO https://github.com/restatedev/restate/releases/latest/download/restate.$RESTATE_PLATFORM.tar.gz && \
-                        tar -xvf restate.$RESTATE_PLATFORM.tar.gz && \
+                        curl -LO https://restate.gateway.scarf.sh/latest/restate-{server,cli}-$RESTATE_PLATFORM.tar.xz && \
+                        tar -xvf restate-server-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-server-$RESTATE_PLATFORM/restate-server && \
+                        tar -xvf restate-cli-$RESTATE_PLATFORM.tar.xz --strip-components=1 restate-cli-$RESTATE_PLATFORM/restate && \
                         chmod +x restate restate-server && \
 
                         # Move the binaries to a directory in your PATH, for example /usr/local/bin (needs sudo):
@@ -1810,13 +1827,13 @@ We will run a simple Restate Greeter service that listens on port `9080` and res
 
                     ```shell
                     docker run --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 \
-                    --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+                    --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
                     ```
 
                     To run commands with the Restate CLI, use the following command:
 
                     ```shell
-                    docker run -it --network=host docker.io/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
+                    docker run -it --network=host docker.restate.dev/restatedev/restate-cli:VAR::RESTATE_VERSION invocations ls
                     ```
 
                     Replace `invocations ls` by the CLI command you want to run.

--- a/docs/get_started/tour.mdx
+++ b/docs/get_started/tour.mdx
@@ -52,7 +52,7 @@ As we go, you will discover how Restate can help you with some intricacies in th
 
 This guide is written for:
 - TypeScript SDK version: `VAR::TYPESCRIPT_SDK_VERSION`
-- Restate Server Docker image: `docker.io/restatedev/restate:VAR::RESTATE_VERSION`
+- Restate Server Docker image: `docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION`
 
 </TabItem>
 <TabItem value="java" label="Java">
@@ -62,7 +62,7 @@ This guide is written for:
 
 This guide is written for:
 - Java SDK version: `VAR::JAVA_SDK_VERSION`
-- Restate Server Docker image: `docker.io/restatedev/restate:VAR::RESTATE_VERSION`
+- Restate Server Docker image: `docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION`
 
 </TabItem>
 <TabItem value="go" label="Go">
@@ -72,7 +72,7 @@ This guide is written for:
 
 This guide is written for:
 - Go SDK version: `VAR::GO_SDK_VERSION`
-- Restate Server Docker image: `docker.io/restatedev/restate:VAR::RESTATE_VERSION`
+- Restate Server Docker image: `docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION`
 
 </TabItem>
 <TabItem value="python" label="Python">
@@ -82,7 +82,7 @@ This guide is written for:
 
 This guide is written for:
 - Python SDK version: `VAR::PYTHON_SDK_VERSION`
-- Restate Server Docker image: `docker.io/restatedev/restate:VAR::RESTATE_VERSION`
+- Restate Server Docker image: `docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION`
 
 </TabItem>
 <TabItem value="rust" label="Rust">
@@ -92,7 +92,7 @@ This guide is written for:
 
     This guide is written for:
     - Rust SDK version: VAR::RUST_SDK_VERSION
-    - Restate Server Docker image: `docker.io/restatedev/restate:VAR::RESTATE_VERSION`
+    - Restate Server Docker image: `docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION`
 
 </TabItem>
 </Tabs>
@@ -3192,7 +3192,7 @@ docker run -d --name jaeger -e COLLECTOR_OTLP_ENABLED=true \
     ```shell !!tabs Docker
     docker run --name restate_dev -p 8080:8080 -p 9070:9070 -p 9071:9071 \
         -e RESTATE_TRACING_ENDPOINT=http://host.docker.internal:4317 \
-        --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+        --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
     ```
     </CodeWithTabs>
 </SubtleStep>

--- a/docs/guides/cluster.mdx
+++ b/docs/guides/cluster.mdx
@@ -99,7 +99,7 @@ Since we are running with 3 nodes, the cluster can tolerate 1 node failure witho
 The `replicated` metadata cluster consists of all nodes since they all run the `metadata-server` role.
 Since the `replicated` metadata cluster requires a majority quorum to operate, the cluster can tolerate 1 node failure without becoming unavailable.
 
-Take a look at the [cluster deployment documentation](/deploy/server/cluster) for more information on how to configure and deploy a distributed Restate cluster.
+Take a look at the [cluster deployment documentation](/deploy/server/cluster/deployment) for more information on how to configure and deploy a distributed Restate cluster.
 
 </Step>
 

--- a/docs/guides/cluster.mdx
+++ b/docs/guides/cluster.mdx
@@ -37,7 +37,7 @@ x-environment: &common-envs
 
 services:
   restate-1:
-    image: docker.io/restatedev/restate:1.2
+    image: docker.restate.dev/restatedev/restate:1.2
     ports:
       # Ingress port
       - "8080:8080"
@@ -59,7 +59,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   restate-2:
-    image: docker.io/restatedev/restate:1.2
+    image: docker.restate.dev/restatedev/restate:1.2
     ports:
       - "25122:5122"
       - "29070:9070"
@@ -76,7 +76,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   restate-3:
-    image: docker.io/restatedev/restate:1.2
+    image: docker.restate.dev/restatedev/restate:1.2
     ports:
       - "35122:5122"
       - "39070:9070"

--- a/docs/guides/lambda-ts.mdx
+++ b/docs/guides/lambda-ts.mdx
@@ -76,7 +76,7 @@ This tutorial shows how to deploy a greeter service written with the Restate Typ
         If you run Restate in a Docker container, then make sure it can using your local AWS creds (defined in ~/.aws):
 
         ```shell
-        docker run -e AWS_PROFILE -v ~/.aws/:/root/.aws --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 --add-host=host.docker.internal:host-gateway docker.io/restatedev/restate:VAR::RESTATE_VERSION
+        docker run -e AWS_PROFILE -v ~/.aws/:/root/.aws --name restate_dev --rm -p 8080:8080 -p 9070:9070 -p 9071:9071 --add-host=host.docker.internal:host-gateway docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
         ```
     </details>
 

--- a/docs/operate/data-backup.mdx
+++ b/docs/operate/data-backup.mdx
@@ -29,7 +29,7 @@ snapshot-interval-num-records = 10000
 ```
 
 This enables automated periodic snapshots to be written to the specified bucket.
-You can also trigger snapshot creation manually using the [`restatectl`](/deploy/server/cluster#controlling-clusters):
+You can also trigger snapshot creation manually using the [`restatectl`](/deploy/server/cluster/deployment#controlling-clusters):
 ```shell
 restatectl snapshots create-snapshot --partition-id <PARTITION_ID>
 ```

--- a/docs/operate/operate.mdx
+++ b/docs/operate/operate.mdx
@@ -13,7 +13,7 @@ import ExampleWidget from "../../src/components/ExampleWidget";
 Restate offers the following tools:
 - [CLI](/develop/local_dev#running-restate-server--cli-locally): A command-line interface to interact with Restate services, deployments, and invocations.
 You can find useful commands throughout this entire section of the documentation.
-- [`restatectl`](/develop/local_dev#running-restate-server--cli-locally): A command-line utility to [control running Restate clusters](/deploy/server/cluster#controlling-clusters).
+- [`restatectl`](/deploy/server/cluster/deployment#getting-restatectl): A command-line utility to [control running Restate clusters](/deploy/server/cluster/deployment#controlling-clusters).
 
 ## Operating Restate and Restate Services
 

--- a/docs/references/restatectl.mdx
+++ b/docs/references/restatectl.mdx
@@ -108,7 +108,7 @@ Options:
 </details>
 
 ## Provision
-Deploys a new Restate cluster. See [Restate Cluster Deployment](/deploy/server/cluster) for details.
+Deploys a new Restate cluster. See [Restate Cluster Deployment](/deploy/server/cluster/deployment) for details.
 
 ## Status
 Provides a comprehensive overview of the cluster's current state. Run:


### PR DESCRIPTION
Should only be merged for 1.2.0, as the https://restate.gateway.scarf.sh/latest/ type links won't work until the 'latest' release has artifacts in the new format (restate-server and restate-cli), and currently latest is 1.1.6 as prereleases do not count.