### PR TITLE
Update doc to match the new `snapshots create` usage

### DIFF
--- a/docs/guides/local-to-replicated.mdx
+++ b/docs/guides/local-to-replicated.mdx
@@ -65,10 +65,10 @@ restatectl status
 <Step stepLabel="4" title="Create snapshots to allow other nodes to join">
 
 For other nodes to join, you need to snapshot every partition because the local loglet is not accessible from other nodes.
-You can find the partition IDs by running `restatectl status`.
+Run the following command to create a snapshot for each partition.
 
 ```shell
-restatectl snapshots create --partition-id <PARTITION_ID>
+restatectl snapshots create
 ```
 
 </Step>


### PR DESCRIPTION
Update doc to match the new `snapshots create` usage

Summary:
`snapshots create` can now create snapshots for all partitions
if no partition ids provided

Related to https://github.com/restatedev/restate/pull/2723
