### PR TITLE
Add Troubleshooting page with duplicate id log server recovery steps

### DIFF
--- a/docs/operate/troubleshooting.mdx
+++ b/docs/operate/troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+sidebar_position: 13
+description: "Resolving common problems with Restate deployments"
+---
+
+import Admonition from '@theme/Admonition';
+import { Terminal } from "../../src/components/code/terminal";
+
+# Troubleshooting
+
+<Admonition type="note" title="Work in progress">
+    This page calls out some scenarios we've identified that require special care. We expect to cover more common issues over time. In the mean time, if you need help with a particular issue, please reach out to us via [Discord](https://discord.com/invite/skW3AZ6uGd) or [Slack](https://join.slack.com/t/restatecommunity/shared_invite/zt-2v9gl005c-WBpr167o5XJZI1l7HWKImA).
+</Admonition>
+
+## Restate Clusters
+
+### Node id misconfiguration puts log server in `data-loss` state
+
+If a misconfigured Restate node with the log server role attempts to join a cluster where the node id is already in use, you will observe that the newly started node aborts with an error:
+
+```log
+ERROR restate_core::task_center: Shutting down: task 4 failed with: Node cannot start a log-server on N3, it has detected that it has lost its data. storage-state is `data-loss`
+```
+
+Restarting the existing node that previously owned this id will also cause it to stop with the same message. Follow these steps to return the initial log server into service without losing its stored log segments.
+
+First, prevent the misconfigured node from starting again until the configuration has been corrected. If this was a brand new node, there should be no data stored on it, and you may delete it altogether.
+
+The reused node id has been marked as having `data-loss`. This precaution that tells the Restate control plane to avoid selecting this node as member of new log nodesets. You can view the current status using the [`restatectl replicated-loglet` tool](/references/restatectl#replicated-loglet):
+
+<Terminal>
+```shell !command
+restatectl replicated-loglet servers
+```
+```log !output
+Node configuration v21
+Log chain v6
+ NODE  GEN   STORAGE-STATE  HISTORICAL LOGLETS  ACTIVE LOGLETS
+ N1    N1:5  read-write     8                   2
+ N2    N2:4  read-write     8                   2
+ N3    N3:6  data-loss      6                   0
+```
+</Terminal>
+
+You should also observe that the control plane is now avoiding using this node for log storage. This will result in reduced fault tolerance or even unavailability, depending on the configured minimum log replication:
+
+<Terminal>
+```shell !command
+restatectl logs list
+```
+```log !output
+Logs v3
+└ Logs Provider: replicated
+ ├ Log replication: {node: 2}
+ └ Nodeset size: 0
+ L-ID  FROM-LSN  KIND        LOGLET-ID  REPLICATION  SEQUENCER  NODESET
+ 0     2         Replicated  0_1        {node: 2}    N2:1       [N1, N2]
+ 1     2         Replicated  1_1        {node: 2}    N2:1       [N1, N2]
+```
+</Terminal>
+
+To restore the original node's ability to accept writes, we can update its metadata using `set-storage-state` subcommand.
+
+<Admonition type="caution" title="Dangerous operation">
+    Only proceed if you are confident that you understand the reason why the node is in this state, and are certain that its locally stored data is still intact. Since Restate cannot automatically validate that it safe to put this node back into service, we must use the `--force` flag to override the default state transition rules.
+</Admonition>
+
+<Terminal>
+```shell !command
+restatectl replicated-loglet set-storage-state --node-id 3 --storage-state 'read-write' --force
+```
+```log !output
+Node N3 storage-state updated from data-loss to read-write
+```
+</Terminal>
+
+You can validate that the server is once again being used for log storage using `logs list` and `replicated-loglet servers` subcommands.

--- a/docs/operate/troubleshooting.mdx
+++ b/docs/operate/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Resolving common problems with Restate deployments"
 ---
 
 import Admonition from '@theme/Admonition';
-import { Terminal } from "../../src/components/code/terminal";
+import { Terminal } from "@site/src/components/code/terminal";
 
 # Troubleshooting
 

--- a/docs/references/restatectl.mdx
+++ b/docs/references/restatectl.mdx
@@ -235,7 +235,7 @@ This lists all known nodes in the cluster and their assigned roles. However, it 
 
 ### Logs status
 
-Shows the effective logs per partition and the current log configuration (provider, replication, and node set). Also accessible via:
+Shows the effective logs per partition and the current log configuration (provider, replication, and nodeset). Also accessible via:
 
 ```shell
 restatectl logs list
@@ -307,7 +307,7 @@ Manage the replicated loglet using `restatectl replicated-loglet`. See [Restate 
 
 When you use the replicated loglet, which is required for distributed operation, the Restate control plane selects nodes on which to replicate the log according to the specified log replication. Each `log-server` node in the cluster has a storage state which determines how the control plane may use this node. The `set-storage-state` tool allows you to manually override this state as operational needs dictate.
 
-New log servers come up in the `provisioning` state and will automatically transition to `read-write`. The `read-write` state means that the node is considered both healthy to read from and accept writes, that is it may be selected as a node set member for new loglet segments.
+New log servers come up in the `provisioning` state and will automatically transition to `read-write`. The `read-write` state means that the node is considered both healthy to read from and accept writes, that is it may be selected as a nodeset member for new loglet segments.
 
 ### list-servers
 
@@ -331,7 +331,7 @@ Log chain v3
 
 Other valid storage include `data-loss`, `read-only`, and `disabled`. Nodes may transition to `data-loss` if they detect that some previously written data is not available. This does not necessarily imply corruption, only that such nodes may not participate in some quorum checks. Such nodes may transition back to `read-write` if they can be repaired.
 
-The `read-only` and `disabled` states are of particular interest to operators. Log servers in `read-only` storage state may continue to serve both reads and writes, but will no longer be selected as participants in new segments' node sets. The control plane will reconfigure existing logs to move away from such nodes.
+The `read-only` and `disabled` states are of particular interest to operators. Log servers in `read-only` storage state may continue to serve both reads and writes, but will no longer be selected as participants in new segments' nodesets. The control plane will reconfigure existing logs to move away from such nodes.
 
 ### set-storage-state
 
@@ -339,7 +339,7 @@ The `read-only` and `disabled` states are of particular interest to operators. L
     `set-storage-state` is a low-level command that allows you to directly set log servers' storage-state. Changing this can lead to cluster unavailability or data loss.
 </Admonition>
 
-Use the `set-storage-state` sub-command to manually set the state, for example to drain log servers. Consider the following example:
+Use the `set-storage-state` sub-command to manually update the log server state, for example to prevent log servers from being included in new nodesets. Consider the following example:
 
 ```shell
 restatectl replicated-loglet set-storage-state --node-id 1 --storage-state read-only
@@ -352,9 +352,7 @@ Node N1 storage-state updated from read-write to read-only
 ```
 </details>
 
-The cluster controller reconfigures the log node set to exclude `N1`. Depending on the configured log replication level, you may see a warning about compromised availability or, if insufficient log servers are available to achieve the minimum required replication, the log will stop accepting writes altogether. You have to take care as `restatectl` does not currently check whether the cluster will be able to generate new node sets with the remaining log servers.
-
-The `disabled` storage state tells Restate that a log server must not be considered for reads or writes - effectively it is no longer a part of the replicated log. It is only safe to transition a `read-only` server to the `disabled` state once the node has been removed from all node sets and any log chain segments that reference it have been trimmed.
+The cluster controller reconfigures the log nodeset to exclude `N1`. Depending on the configured log replication level, you may see a warning about compromised availability or, if insufficient log servers are available to achieve the minimum required replication, the log will stop accepting writes altogether. You have to take care as `restatectl` does not currently check whether the cluster will be able to generate new nodesets with the remaining log servers.
 
 <Admonition type="tip" title="Log details">
     You can examine logs using `restatectl logs describe`.


### PR DESCRIPTION
Follow-up to #540:

- add troubleshooting guide to cover duplicate log-server node id recovery
- remove explicit mention of `read-only` and `disabled` from the `restatectl` reference page