### PR TITLE
Review docs, drop mentions of `default-log-replication`

### DIFF
--- a/docs/deploy/server/cluster.mdx
+++ b/docs/deploy/server/cluster.mdx
@@ -41,15 +41,18 @@ cluster-name = "CLUSTER_NAME"
 advertised-address = "ADVERTISED_ADDRESS"
 # At most one node can be configured with auto-provision = true
 auto-provision = false
+# Default replication factor for both the logs and the partitions.
+#
+# Replicate the data to 2 nodes. This requires that the cluster has at least 2 nodes to
+# become operational. If the cluster has at least 3 nodes, then it can tolerate 1 node failure.
+#
+# This also controls the default partition replication. A value of 2 means each partition
+# will be running on (max) of 2 nodes, ensuring redundancy and fault tolerance.
+default-replication = 2
 
 [bifrost]
 # Only the replicated Bifrost provider can be used in a distributed deployment
 default-provider = "replicated"
-
-[bifrost.replicated-loglet]
-# Replicate the data to 2 nodes. This requires that the cluster has at least 2 nodes to
-# become operational. If the cluster has at least 3 nodes, then it can tolerate 1 node failure.
-default-log-replication = 2
 
 [metadata-server]
 # To tolerate node failures, use the replicated metadata server
@@ -79,7 +82,7 @@ If no node is allowed to auto provision, then you have to manually provision the
 Refer to the [Cluster provisioning](#cluster-provisioning) section for more information.
 
 The log provider needs to be configured with `default-provider = "replicated"`.
-The `default-log-replication` should be set to the number of nodes that the data should be replicated to.
+The `default-replication` should be set to the number of nodes that the data should be replicated to.
 If you run at least `2 * default-replication-property - 1` nodes, then the cluster can tolerate `default-replication-property - 1` node failures.
 
 The metadata server type should be set to `replicated` to tolerate node failures.

--- a/docs/operate/clusters.mdx
+++ b/docs/operate/clusters.mdx
@@ -286,13 +286,12 @@ You can expand an existing cluster by adding new nodes after it has been started
     A Restate cluster can initially be started with a single node.
     Follow the [cluster deployment instructions](/deploy/server/cluster) and ensure that:
     - It uses the replicated loglet. If you use local loglet, check [this migration guide](/guides/local-to-replicated).
-    - `default-log-replication` is set to 1
+    - `default-replication` is set to 1
     - [Snapshotting is enabled](/operate/data-backup#snapshotting), to ensure that newly added nodes are fully utilized by the system.
 
     ```toml
-    [bifrost.replicated-loglet]
     # Replicating data to one node: the cluster cannot tolerate node failures.
-    default-log-replication = 1
+    default-replication = 1
     ```
 
 </Step>
@@ -309,20 +308,21 @@ This allows the new node to discover the metadata servers and join the cluster.
 
     <Terminal>
         ```shell !command
-        restatectl config set --log-replication 2
+        restatectl config set --log-replication 2 --partition-replication 2
         ```
 
         ```shell !output
         ⚙️ Cluster Configuration
-        ├ Number of partitions: 8
-        ├ Partition replication: *
+        ├ Number of partitions: 4
+        -├ Partition replication: {node: 1}
+        +├ Partition replication: {node: 2}
         └ Logs Provider: replicated
         - ├ Log replication: {node: 1}
         + ├ Log replication: {node: 2}
         └ Nodeset size: 0
 
 
-        ? Apply changes? (y/n) › yes
+        ? Apply changes? (y/n) › no
         ```
     </Terminal>
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -87,7 +87,7 @@ const sidebars = {
                         description:
                             "This is the reference of Restate's Admin API endpoint.",
                     },
-                    items: require("./docs/adminapi/sidebar.ts")
+                    items: require("./docs/adminapi/sidebar.ts").default,
                 }
             ]
         },


### PR DESCRIPTION
Review docs, drop mentions of `default-log-replication`

Summary:
- This also clearns mentions of default-partition-replications
- Fixes a bug in sidebar
