### PR TITLE
Refer to templated docker image in cluster guide and remove explicit roles

### DIFF
--- a/docs/deploy/server/cluster.mdx
+++ b/docs/deploy/server/cluster.mdx
@@ -31,8 +31,6 @@ This page describes how you can deploy a distributed Restate cluster.
 To deploy a distributed Restate cluster without external dependencies, you need to configure the following settings in your [server configuration](/operate/configuration/server):
 
 ```toml restate.toml
-# Let every node run all roles
-roles = ["metadata-server", "admin", "worker", "log-server"]
 # Every node needs to have a unique node name
 node-name = "UNIQUE_NODE_NAME"
 # All nodes need to have the same cluster name

--- a/docs/guides/cluster.mdx
+++ b/docs/guides/cluster.mdx
@@ -24,8 +24,6 @@ To deploy a 3 node distributed Restate cluster, create a file `docker-compose.ym
 ```yaml docker-compose.yml
 x-environment: &common-env
   RESTATE_CLUSTER_NAME: "restate-cluster"
-  # Every node runs every role
-  RESTATE_ROLES: '["admin", "worker", "log-server", "metadata-server"]'
   # For more on logging, see: https://docs.restate.dev/operate/monitoring/logging
   RESTATE_LOG_FILTER: "restate=info"
   RESTATE_BIFROST__DEFAULT_PROVIDER: "replicated"
@@ -43,7 +41,7 @@ x-environment: &common-env
   RESTATE_WORKER__SNAPSHOTS__AWS_SECRET_ACCESS_KEY: "minioadmin"
 
 x-defaults: &defaults
-  image: docker.restate.dev/restatedev/restate:1.2
+  image: docker.restate.dev/restatedev/restate:VAR::RESTATE_VERSION
   extra_hosts:
     - "host.docker.internal:host-gateway"
 

--- a/docs/guides/local-to-replicated.mdx
+++ b/docs/guides/local-to-replicated.mdx
@@ -39,7 +39,7 @@ destination = "s3://snapshots-bucket/cluster-prefix"
 
 <Step stepLabel="2" title="Enable the replicated loglet">
 
-To be able to use the replicated loglet, make sure the node includes the `log-server` role as following.
+To be able to use the replicated loglet, make sure the node includes the `log-server` role if you configure the roles explicitly.
 
 ```toml restate.toml
 roles = [
@@ -89,7 +89,6 @@ To add more nodes to your cluster, you need to start new Restate servers with th
 If you want the new nodes to participate in the replicated metadata cluster, then they should run the `metadata-server` role and use the `replicated` metadata server.
 
 ```toml restate.toml
-roles = ["metadata-server", "admin", "worker", "log-server"]
 cluster-name = "my-cluster"
 
 [metadata-client]

--- a/docs/operate/configuration/server.mdx
+++ b/docs/operate/configuration/server.mdx
@@ -23,7 +23,7 @@ The Restate Server accepts a [TOML](https://toml.io/en/) configuration file that
 Restate server accepts a sub-set of the configuration through command-line arguments, you can see all available options by adding `--help` to `restate-server`.
 
 The order of applying configuration layers follows the following order:
-1. Built-in defaults 
+1. Built-in defaults
 2. Configuration file (`--config-file` or via `RESTATE_CONFIG`)
 3. Environment variables
 4. Command line arguments (`--cluster-name=<VALUE>`)
@@ -35,7 +35,7 @@ Every layer overrides the previous. For instance, command-line arguments will ov
 ### Environment variables
 You can override any configuration entry with an environment variable, this overrides values loaded from the configuration file. To do that, the following rule applies:
 
-* Prefix the configuration entry key with `RESTATE_` 
+* Prefix the configuration entry key with `RESTATE_`
 * Separate every nested struct with `__` (double underscore) and all hyphens `-` with a `_` (single underscore).
 
 For example, to override the `admin.bind-address`, the corresponding environment variable is `RESTATE_ADMIN__BIND_ADDRESS`.
@@ -51,7 +51,8 @@ Example output:
 roles = [
     "worker",
     "admin",
-    "metadata-store",
+    "metadata-server",
+    "log-server",
 ]
 cluster-name = "mycluster"
 ...
@@ -69,4 +70,3 @@ Then send the signal to the process ID returned from `pgrep`'s output:
 kill -USR1 994921
 ```
 Observe the output of the server for a dump of the configuration file contents.
-


### PR DESCRIPTION
Removing explicitly configured roles in our documentation will prepare users for the upcoming split of the worker and http-ingress role. Otherwise, if users configure the roles explicitly, they risk that the ingress is not started when upgrading their restate-server.

Once this PR is merged, we should create a new documentation release to update the cluster guide to point towards Restate 1.3.