### PR TITLE
Add description how to deploy Restate services behind a load balancer

### DIFF
--- a/docs/deploy/services/faas/_category_.json
+++ b/docs/deploy/services/faas/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "FaaS",
-  "position": 3,
+  "position": 2,
   "link": {
     "type": "generated-index",
     "title": "FaaS"

--- a/docs/deploy/services/kubernetes.md
+++ b/docs/deploy/services/kubernetes.md
@@ -1,14 +1,21 @@
 ---
-title: "Kubernetes"
-sidebar_position: 2
+title: "Standalone/Kubernetes"
+sidebar_position: 1
 description: "Learn how to run Restate applications on Kubernetes."
 ---
 
 import Admonition from '@theme/Admonition';
 
-# Deploying Restate services to Kubernetes
+# Deploying Restate services
 
-This page describes how to deploy Restate services on [Kubernetes](https://kubernetes.io/).
+You can deploy your Restate service on any standalone machine.
+If you want to spread load across multiple machines, it is best to put your services behind a load balancer (L4/L7).
+
+<Admonition type="info" title="Running services behind a load balancer">
+    If you want to run your service behind a load balancer, please make sure that you configure the load balancer to allow HTTP2 traffic.
+</Admonition>
+
+## Deploying Restate services to Kubernetes
 
 Service deployments can be deployed like any Kubernetes service; a Deployment of more than one replica is generally appropriate,
 and a Service is used to provide a stable DNS name and IP for the pods.
@@ -16,7 +23,7 @@ If your services are running over HTTP2 (the default), each Restate partition wi
 However, because there are many partitions (by default 24, typically more in a larger cluster) your pods should get a reasonably
 even distribution of traffic even without a L7 load balancing solution (Cilium, Istio etc).
 
-### Deployment and Service
+### Kubernetes Deployment and Service definition
 
 A simple deployment setup with a single pod in Kubernetes is as follows:
 


### PR DESCRIPTION
This commit extends our documentation to describe how to deploy a Restate service behind a load balancer.

A user ran into this problem and was asking for specifying the requirements for deploying a Restate service. I wasn't really sure where this would fit best. Maybe you have a better idea @gvdongen.