### PR TITLE
pgsql-bind-address is disabled by default

### DIFF
--- a/docs/deploy/server/cluster.mdx
+++ b/docs/deploy/server/cluster.mdx
@@ -67,10 +67,6 @@ bind-address = "ADMIN_BIND_ADDRESS"
 [ingress]
 # Make sure it does not conflict with other nodes
 bind-address = "INGRESS_BIND_ADDRESS"
-
-[admin.query-engine]
-# Make sure it does not conflict with other nodes
-pgsql-bind-address = "PGSQL_BIND_ADDRESS"
 ```
 
 It is important that every Restate node you start has a unique `node-name` specified.


### PR DESCRIPTION
We no longer need to make sure that the pgsql-bind-address conflicts because it is disabled by default with 1.4.0. See https://github.com/restatedev/restate/issues/3088.