### PR TITLE
Remove single quotes from invoking handler through UI

### DIFF
--- a/docs/get_started/tour.mdx
+++ b/docs/get_started/tour.mdx
@@ -411,7 +411,7 @@ We can either use the Restate UI playground or `curl`.
 <TabItem value="ts" label="TypeScript">
 For example, add a ticket `seat2B` to the cart of Mary by calling the `addTicket` handler of the `CartObject`.
 
-In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with body `'"seat2B"'`.
+In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with key `Mary` and body `"seat2B"`.
 
 Or via `curl`:
 
@@ -432,7 +432,7 @@ curl -X POST localhost:8080/CartObject/Mary/checkout
 <TabItem value="java" label="Java">
 For example, add a ticket `seat2B` to the cart of Mary by calling the `addTicket` handler of the `CartObject`:
 
-In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with body `'"seat2B"'`.
+In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with key `Mary` and body `"seat2B"`.
 
 Or via `curl`:
 
@@ -453,7 +453,7 @@ curl -X POST localhost:8080/CartObject/Mary/checkout
 <TabItem value="go" label="Go">
     For example, add a ticket `seat2B` to the cart of Mary by calling the `AddTicket` handler of the `CartObject`:
 
-    In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with body `'"seat2B"'`.
+    In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with key `Mary` and body `"seat2B"`.
 
     Or via `curl`:
 
@@ -474,7 +474,7 @@ curl -X POST localhost:8080/CartObject/Mary/checkout
 <TabItem value="py" label="Python">
         For example, add a ticket `seat2B` to the cart of Mary by calling the `addTicket` handler of the `CartObject`:
 
-        In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with body `'"seat2B"'`.
+        In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with key `Mary` and body `"seat2B"`.
 
         Or via `curl`:
 
@@ -495,7 +495,7 @@ curl -X POST localhost:8080/CartObject/Mary/checkout
     <TabItem value="rust" label="Rust">
         For example, add a ticket `seat2B` to the cart of Mary by calling the `addTicket` handler of the `CartObject`:
 
-        In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with body `'"seat2B"'`.
+        In the UI, click on the `CartObject` service, then on `Playground`, and invoke your handler from there with key `Mary` and body `"seat2B"`.
 
         Or via `curl`:
 


### PR DESCRIPTION
When invoking a handler through the UI the body does not have to be wrapped within single quotes.

This fixes #651.