### PR TITLE
Fix default server configuration link

### DIFF
--- a/docs/operate/configuration/server.mdx
+++ b/docs/operate/configuration/server.mdx
@@ -16,7 +16,7 @@ The Restate Server has a wide range of configuration options to tune it accordin
 
 ## Configuration file
 
-The Restate Server accepts a [TOML](https://toml.io/en/) configuration file that can be specified either providing the command-line option `--config-file=<PATH>` or setting the environment variable `RESTATE_CONFIG=<PATH>`. If not set, the [default configuration](#default-configuration) will be applied.
+The Restate Server accepts a [TOML](https://toml.io/en/) configuration file that can be specified either providing the command-line option `--config-file=<PATH>` or setting the environment variable `RESTATE_CONFIG=<PATH>`. If not set, the [default configuration](/references/server_config#default-configuration) will be applied.
 
 ## Overrides
 


### PR DESCRIPTION
It seems that in the https://github.com/restatedev/documentation/pull/547, the default server configuration was moved, but the link was not updated. This PR fixes the link.