### PR TITLE
Fix TOML syntax for Kafka cluster configuration

### DIFF
--- a/docs/invoke/kafka.mdx
+++ b/docs/invoke/kafka.mdx
@@ -91,8 +91,8 @@ You can invoke handlers via Kafka events, by doing the following:
     [[ingress.kafka-clusters]]
     name = "my-cluster"
     brokers = ["PLAINTEXT://broker:9092"]
-    sasl.username = "me"
-    sasl.password = "pass"
+    "sasl.username" = "me"
+    "sasl.password" = "pass"
     ```
 
     For the full list of options, check [librdkafka configuration](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md).


### PR DESCRIPTION
In this docs page (https://docs.restate.dev/services/invocation/kafka#kafka-connection-configuration), the options that go to librdkafka need to be string, string, as they go to a `HashMap<String, String>`.
I had the misfortune of spending a day figuring this out, as I didn't pay close attention to the following line a few paras below - _"The options field is optional and accepts any [librdkafka configuration](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md) parameter."_
Missed the implication that librdkafka options go in the subscription registration request, i.e.,
```shell
curl localhost:9070/subscriptions --json '{
"source": "kafka://my-cluster/my-topic",
"sink": "service://MyService/Handle",
"options": {"auto.offset.reset": "earliest"}
}'
```